### PR TITLE
Fix FLIR vehicle tracking (#538) and copilot cockpit LOD (#556)

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -1,5 +1,7 @@
 **0.7.7.4**
 
+ - Fix copilot seat rendering wrong interior LOD (missing upper console) #556
+ - Fix FLIR lock/track of vehicles: lock key was dead in gunner view, and locking now targets the object the camera ray hits #538
  - Fix FD IAS keybind
  - Add condition for ACE actions when cabin doors are blocked by units or FRIES
  

--- a/addons/UH60/config/turrets/copilot.hpp
+++ b/addons/UH60/config/turrets/copilot.hpp
@@ -5,6 +5,10 @@ class CopilotTurret: CopilotTurret {
   canHideGunner = 0;
   viewGunnerInExternal = 1;
   gunnerUsesPilotView = 1;
+  // 1100 = View - Pilot LOD; without these the turret defaults to the door-gunner
+  // View - Gunner LOD and the copilot cockpit loses its upper console (#556)
+  LODTurnedIn = 1100;
+  LODTurnedOut = 1100;
   memoryPointGunnerOptics = "";
   memoryPointGunnerOutOptics = "";
   gunnerRightHandAnimName="Cyclic_left";

--- a/addons/UH60/config/turrets/copilotFLIR.hpp
+++ b/addons/UH60/config/turrets/copilotFLIR.hpp
@@ -36,6 +36,10 @@ class CopilotTurret: CopilotTurret {
   soundAttenuationTurret = "SemiOpenHeliAttenuation";
   viewGunnerInExternal = 1;
   gunnerUsesPilotView = 1;
+  // 1100 = View - Pilot LOD; without these the turret defaults to the door-gunner
+  // View - Gunner LOD and the copilot cockpit loses its upper console (#556)
+  LODTurnedIn = 1100;
+  LODTurnedOut = 1100;
   gunnerRightHandAnimName="Cyclic_left";
   gunnerLeftHandAnimName="Collective_left";
   gunnerLeftLegAnimName="Pedal_Left_CP";

--- a/addons/uh60_flir/functions/fnc_handleSlew.sqf
+++ b/addons/uh60_flir/functions/fnc_handleSlew.sqf
@@ -63,8 +63,9 @@ if (vtx_uh60_flir_isSlewing) then {
             (_slewOrigin # 2) + (_inputY * _rateY)
         ];
 
-        private _intersect = [_originPos, _newDir # 0, _newDir # 1] call vtx_uh60_flir_fnc_intersectAtPolar;
-        if (!isNil "_intersect") then {
+        private _intersectResult = [_originPos, _newDir # 0, _newDir # 1] call vtx_uh60_flir_fnc_intersectAtPolar;
+        if (!isNil "_intersectResult") then {
+            private _intersect = _intersectResult # 0; // slew stays a position lock; object tracking is setStabilization's job
             if (!_isGunnerView || vtx_uh60_flir_playerIsCopilot) then {_vehicle setPilotCameraTarget _intersect};
             [getPilotCameraDirection _vehicle, getPilotCameraTarget _vehicle # 1] call vtx_uh60_flir_fnc_syncPilotCamera;
         } else {

--- a/addons/uh60_flir/functions/fnc_intersectAtPolar.sqf
+++ b/addons/uh60_flir/functions/fnc_intersectAtPolar.sqf
@@ -1,3 +1,4 @@
+// Returns [intersect position ASL, hit object (objNull for terrain)] or nil on no hit
 params ["_origin","_angleX","_angleY"];
 
 scopeName "return";
@@ -10,6 +11,7 @@ for "_i" from 0 to 15 step 1 do {
   private _endPos = _startPos vectorAdd _vectorIntersect;
   private _intersect = lineIntersectsSurfaces [_startPos, _endPos, (vehicle player)];
   if(count _intersect > 0) then {
-    (_intersect # 0 # 0) breakOut "return";
+    (_intersect # 0) params ["_intersectPos", "", "_hitObject", "_hitParent"];
+    [_intersectPos, [_hitObject, _hitParent] select (!isNull _hitParent)] breakOut "return";
   };
 };

--- a/addons/uh60_flir/functions/fnc_setStabilization.sqf
+++ b/addons/uh60_flir/functions/fnc_setStabilization.sqf
@@ -29,14 +29,30 @@ vtx_uh60_flir_pilotCameraTarget params ["_isTracking", "", "_trackObj"];
 private _originPos = hct_vehicle modelToWorldVisualWorld (getPilotCameraPosition hct_vehicle);
 private _cameraVectorWorld = hct_vehicle vectorModelToWorld (getPilotCameraDirection hct_vehicle);
 private _slewOrigin = (_cameraVectorWorld) call CBA_fnc_vect2Polar;
-private _intersect = [_originPos, _slewOrigin # 1, _slewOrigin # 2] call vtx_uh60_flir_fnc_intersectAtPolar;
+private _intersectResult = [_originPos, _slewOrigin # 1, _slewOrigin # 2] call vtx_uh60_flir_fnc_intersectAtPolar;
 
-if (isNil "_intersect") exitWith {};
+if (isNil "_intersectResult") exitWith {};
+_intersectResult params ["_intersect", "_hitObject"];
 
-private _nearObjects = nearestObjects [ASLtoAGL _intersect, ["Land", "Air", "Ship"], 5];
-if (_nearObjects isNotEqualTo []) then {
-  hct_vehicle setPilotCameraTarget (_nearObjects # 0);
-  [[], _intersect, (_nearObjects # 0)] call vtx_uh60_flir_fnc_syncPilotCamera;
+// Prefer the object the ray actually hit — a proximity search around the impact
+// point misses large vehicles (origin > 5 m from the hull) and aircraft entirely,
+// because a near-miss ray lands on terrain far behind the target (#538)
+private _trackTarget = objNull;
+if (!isNull _hitObject) then {
+  private _hitVehicle = vehicle _hitObject; // crew hit resolves to their vehicle
+  if (_hitVehicle isKindOf "LandVehicle" || {_hitVehicle isKindOf "Air"} || {_hitVehicle isKindOf "Ship"} || {_hitVehicle isKindOf "Man"}) then {
+    _trackTarget = _hitVehicle;
+  };
+};
+// Fallback for near misses on movers: sim position trails the rendered hull
+if (isNull _trackTarget) then {
+  private _nearObjects = nearestObjects [ASLtoAGL _intersect, ["Land", "Air", "Ship"], 10];
+  if (_nearObjects isNotEqualTo []) then {_trackTarget = _nearObjects # 0};
+};
+
+if (!isNull _trackTarget) then {
+  hct_vehicle setPilotCameraTarget _trackTarget;
+  [[], _intersect, _trackTarget] call vtx_uh60_flir_fnc_syncPilotCamera;
 } else {
   if ((getPilotCameraTarget hct_vehicle) # 0) then {
 

--- a/addons/uh60_flir/initKeybinds.sqf
+++ b/addons/uh60_flir/initKeybinds.sqf
@@ -1,6 +1,8 @@
 //addUserActionEventHandler ["transportNightVision", "Activate", vtx_uh60_flir_fnc_keyVisionMode];
 addUserActionEventHandler ["vehLockTurretView", "Activate", {
-  if (!vtx_uh60_flir_controllable || {cameraView == "GUNNER"}) exitWith {};
+  // GUNNER-view guard must not block the copilot: turret optics are the copilot's
+  // primary FLIR view, only doorgunners should keep vanilla turret lock (#538)
+  if (!vtx_uh60_flir_controllable || {cameraView == "GUNNER" && {!vtx_uh60_flir_playerIsCopilot}}) exitWith {};
   if (vtx_uh60_flir_isInScriptedCamera) then {
     [
         AGLToASL positionCameraToWorld [0, 0, 0],


### PR DESCRIPTION
## What this fixes

**#556 — Copilot cockpit geometry missing (upper console, interior)**
The Copilot Turret FLIR change (0.7.6.9, #546) converted the copilot seat into a turret, but `copilotFLIR.hpp`/`copilot.hpp` never set `LODTurnedIn`/`LODTurnedOut`. A turret defaults to the **View - Gunner LOD (1000)** — authored for the door gunners with the front cockpit stripped — so the copilot seat rendered with the upper console and much of the interior missing, while the pilot (View - Pilot LOD) was unaffected. Both copilot turret configs now set `LODTurnedIn = 1100; LODTurnedOut = 1100`. (Every other seated turret in the mod already sets this explicitly — cargo turrets and troop commander use 1200.)

**#538 — FLIR won't lock/track vehicles**
Two layers, matching the report's "worked 50% of the time, now not at all":
1. The 0.7.6 hotfix (#531) moved the lock trigger to an `addUserActionEventHandler` in `initKeybinds.sqf` whose guard exits whenever `cameraView == "GUNNER"` — the copilot's primary FLIR view (and the *only* optics view since the turret change). The guard now only excludes non-copilot gunners (doorgunners keep vanilla turret-lock behavior).
2. Acquisition was fragile: `fnc_intersectAtPolar` discarded the object the ray hit and `fnc_setStabilization` searched for a vehicle within **5 m** of the impact *point* — which fails for large vehicles (origin > 5 m from the hull hit), moving vehicles (sim position trails the rendered hull), and aircraft (a near-miss ray lands on terrain far behind; nothing is near that point). `fnc_intersectAtPolar` now also returns the hit object and `fnc_setStabilization` locks the ray-hit vehicle directly, keeping the proximity search only as a widened (10 m) fallback. The slew path keeps its position-lock behavior unchanged.

## Testing needed (no build tooling on this machine — config/SQF changes are validator-clean)

- [ ] Copilot seat on UH60M / HH60 / SLICK: upper console + interior render in 1st person, optics, and 3rd person (#556)
- [ ] Lock key as copilot in turret optics (gunner view), scripted camera, and cockpit MFD view: stationary ground vehicle, moving vehicle, flying helicopter (#538)
- [ ] Doorgunner lock key behavior unchanged
- [ ] Pilot camera slew/stab (position lock and unlock toggle) unchanged
- [ ] MP dedicated check with copilot as non-owner

Closes #538, Closes #556



