### PR TITLE
Fix FLIR vehicle tracking (#538) & temporarily remove turret camera

### DIFF
--- a/CHANGELOG-DEV.md
+++ b/CHANGELOG-DEV.md
@@ -1,5 +1,7 @@
 **0.7.7.4**
 
+ - Fix copilot cockpit interior not rendering (missing upper console, no get-in animation). Copilot turret optics are temporarily removed - the seat renders correctly again; optics return once the model gains a View - Gunner LOD #556
+ - Fix FLIR vehicle lock/tracking for both pilots in PiP and both fullscreen views: lock key now works in every view, locking targets the object the camera ray hits (with a boresight cone fallback for movers), and the cameras actively follow the tracked vehicle #538
  - Fix FD IAS keybind
  - Add condition for ACE actions when cabin doors are blocked by units or FRIES
  

--- a/addons/UH60/config/cfgVehicles.hpp
+++ b/addons/UH60/config/cfgVehicles.hpp
@@ -327,7 +327,7 @@ class CfgVehicles {
         };
         class Turrets: Turrets
         {
-            #include "turrets\copilotFLIR.hpp"
+            #include "turrets\copilot.hpp" // #556: proven-working turret for ALL copilots; copilotFLIR.hpp returns when the model gains a View-Gunner LOD
             #include "turrets\doorgunsTurnOut.hpp"
         };
         class Exhausts
@@ -523,7 +523,7 @@ class CfgVehicles {
         driverWeaponsInfoType = "Rsc_vtx_MELB_Turret_UnitInfo";
         class Turrets: Turrets
         {
-            #include "turrets\copilotFLIR.hpp"
+            #include "turrets\copilot.hpp" // #556: proven-working turret for ALL copilots; copilotFLIR.hpp returns when the model gains a View-Gunner LOD
             class MainTurret: MainTurret {};
             class RightDoorGun: RightDoorGun {};
             #include "turrets\cargoTurrets.hpp"

--- a/addons/UH60/config/turrets/copilot.hpp
+++ b/addons/UH60/config/turrets/copilot.hpp
@@ -5,6 +5,11 @@ class CopilotTurret: CopilotTurret {
   canHideGunner = 0;
   viewGunnerInExternal = 1;
   gunnerUsesPilotView = 1;
+  soundAttenuationTurret = "SemiOpenHeliAttenuation"; // carried over from copilotFLIR.hpp so cockpit audio keeps its attenuation (#510)
+  // 1100 = View - Pilot LOD; without these the turret defaults to the door-gunner
+  // View - Gunner LOD and the copilot cockpit loses its upper console (#556)
+  LODTurnedIn = 1100;
+  LODTurnedOut = 1100;
   memoryPointGunnerOptics = "";
   memoryPointGunnerOutOptics = "";
   gunnerRightHandAnimName="Cyclic_left";
@@ -25,7 +30,10 @@ class CopilotTurret: CopilotTurret {
   class ViewGunner: ViewPilot {
     #include "ViewPilot.hpp"
   };
-  class OpticsIn {};
+  // TEST BUILD (#556 A/B): OpticsIn removed - pre-FLIR copilots had no optics
+  // and rendered the View-Pilot LOD correctly; the optics turret conversion is
+  // the suspected trigger for the resolution-LOD fallback. SLICK = no-optics
+  // probe, UH60M (copilotFLIR.hpp) keeps optics as the control.
   class Hitpoints {};
   class Components {
     class SensorsManagerComponent {

--- a/addons/UH60/config/turrets/copilotFLIR.hpp
+++ b/addons/UH60/config/turrets/copilotFLIR.hpp
@@ -21,13 +21,19 @@ class CopilotTurret: CopilotTurret {
   minFov = 0.25;
   maxFov = 0.9;
   initFov = 0.75;
-  memoryPointGunnerOptics = "flir_cam_pos";
-  memoryPointGunnerOutOptics = "flir_cam_pos";
+  // #556 HOTFIX: optics classes removed. An optics turret makes the engine
+  // render the View-Gunner LOD, which vtx_uh60.p3d does not have, so the
+  // copilot fell back to a gutted resolution LOD (see-through console).
+  // A/B-proven in-game 2026-08-16: only physical absence of OpticsIn heals it.
+  // Restore the optics (and this seat's turret FLIR view) once the model
+  // gains a View - Gunner (1000) LOD - a copy of View - Pilot (1100) works.
+  memoryPointGunnerOptics = "";
+  memoryPointGunnerOutOptics = "";
   gunBeg = "flir_cam_dir";
   gunEnd = "flir_cam_pos";
   turretFollowFreeLook = 0;
   turretInfoType = "Rsc_vtx_MELB_Turret_UnitInfo";
-  #include "OpticsIn.hpp"
+  // #include "OpticsIn.hpp"
   CanEject=0;
   gunnerAction = "UH60_Pilot";
   gunnerInAction = "UH60_Pilot";
@@ -36,6 +42,10 @@ class CopilotTurret: CopilotTurret {
   soundAttenuationTurret = "SemiOpenHeliAttenuation";
   viewGunnerInExternal = 1;
   gunnerUsesPilotView = 1;
+  // 1100 = View - Pilot LOD; without these the turret defaults to the door-gunner
+  // View - Gunner LOD and the copilot cockpit loses its upper console (#556)
+  LODTurnedIn = 1100;
+  LODTurnedOut = 1100;
   gunnerRightHandAnimName="Cyclic_left";
   gunnerLeftHandAnimName="Collective_left";
   gunnerLeftLegAnimName="Pedal_Left_CP";

--- a/addons/uh60_flir/functions/fnc_handleKeyInputs.sqf
+++ b/addons/uh60_flir/functions/fnc_handleKeyInputs.sqf
@@ -25,24 +25,23 @@ if (_visionMode > 0) then {
 
 if (!vtx_uh60_flir_controllable) exitWith {};
 
-// Switch to addUserActionEventHandler to fix inconsistent behavior
-// // Stabilize enables object tracking anywhere
-// private _stab = inputAction "vehLockTurretView";
-// if (_stab > 0) then {
-//   if (vtx_uh60_flir_inputStabilize == 0) then {
-//     vtx_uh60_flir_inputStabilize = ceil _stab;
-//     if (vtx_uh60_flir_isInScriptedCamera) then {
-//       [
-//          AGLToASL positionCameraToWorld [0, 0, 0],
-//          AGLToASL positionCameraToWorld [0, 0, 5000]
-//       ] call vtx_uh60_flir_fnc_setStabilization;
-//     } else {
-//       [] call vtx_uh60_flir_fnc_setStabilization;
-//     };
-//   };
-// } else {
-//   vtx_uh60_flir_inputStabilize = 0;
-// }; // Stabilize
+// Stabilize/lock in the scripted camera must be POLLED: vanilla user action
+// events do not fire while a cameraEffect camera is active (the cockpit/optics
+// path keeps the addUserActionEventHandler in initKeybinds.sqf) (#538)
+if (vtx_uh60_flir_isInScriptedCamera) then {
+  private _stab = inputAction "vehLockTurretView";
+  if (_stab > 0) then {
+    if (vtx_uh60_flir_inputStabilize == 0) then {
+      vtx_uh60_flir_inputStabilize = ceil _stab;
+      [
+         AGLToASL positionCameraToWorld [0, 0, 0],
+         AGLToASL positionCameraToWorld [0, 0, 5000]
+      ] call vtx_uh60_flir_fnc_setStabilization;
+    };
+  } else {
+    vtx_uh60_flir_inputStabilize = 0;
+  };
+}; // Stabilize
 
 if (vtx_uh60_flir_playerIsCopilot) then {
   // Laser

--- a/addons/uh60_flir/functions/fnc_handleSlew.sqf
+++ b/addons/uh60_flir/functions/fnc_handleSlew.sqf
@@ -100,6 +100,6 @@ if (vtx_uh60_flir_isSlewing) then {
         [getPilotCameraDirection _vehicle, objNull] call vtx_uh60_flir_fnc_syncPilotCamera;
     };
 };
-if (!vtx_uh60_flir_setting_useScriptedCamera && vtx_uh60_flir_playerIsCopilot && cameraView == "GUNNER") then {
-  [_vehicle, true] call vtx_uh60_flir_fnc_syncAnimation;
-};
+// (turret-optics animation sync removed with the Use Scripted Camera setting -
+// the copilot optics mode is disabled until the model gains a View - Gunner
+// LOD, #560; restore both together with the optics)

--- a/addons/uh60_flir/functions/fnc_handleSlew.sqf
+++ b/addons/uh60_flir/functions/fnc_handleSlew.sqf
@@ -16,7 +16,6 @@
 params ["_vehicle"];
 
 private _isGunnerView = cameraView isEqualTo "GUNNER";
-//hintSilent format ["_mouseSlew: %1\n_isGunnerView: %2", "_____", cameraView isEqualTo "GUNNER"];
 
 // fov
 if (_isGunnerView) then {
@@ -25,20 +24,6 @@ if (_isGunnerView) then {
         vtx_uh60_flir_FOV = _fov;
         [_fov] call vtx_uh60_flir_fnc_setFOV;
     };
-};
-
-// get current dir
-(getPilotCameraRotation _vehicle) params ["_azimuth", "_elevation"];
-
-// Active follow: a target set while already inside the gunner view / scripted
-// camera is not steered by the engine, so aim the pilot camera at the tracked
-// object ourselves every frame. NOTE: the engine's getPilotCameraTarget does
-// NOT return the object - the mod patches it into element 2 of its own state
-// variable in fnc_syncPilotCamera, which is the only valid source (#538)
-private _trackedObj = vtx_uh60_flir_pilotCameraTarget param [2, objNull];
-if (!isNull _trackedObj) then {
-  private _trackOrigin = _vehicle modelToWorldVisualWorld (getPilotCameraPosition _vehicle);
-  _vehicle setPilotCameraDirection (_vehicle vectorWorldToModelVisual (_trackOrigin vectorFromTo getPosASLVisual _trackedObj));
 };
 
 // check key slew
@@ -52,27 +37,84 @@ if _keySlew then {
     _inputY = vtx_uh60_flir_up - vtx_uh60_flir_down;
 } else {
     // check mouse slew
-    //setMousePosition [5,5]; // can't use map while flir is on, also doesn't seem to be needed.
     _inputX = inputAction "AimRight" - inputAction "AimLeft";
     _inputY = inputAction "AimUp" - inputAction "AimDown";
     _mouseSlew = (_inputX != 0 || {_inputY != 0});
 };
 vtx_uh60_flir_isSlewing = _keySlew || {vtx_uh60_flir_isInScriptedCamera && {_mouseSlew}} || {vtx_uh60_flir_slewAim && {_mouseSlew}} || {_isGunnerView && {_mouseSlew}};
 
+// Deliberate FLIR movement: key slew always counts; mouse only above a small
+// deadzone so an accidental mouselook twitch cannot demote a vehicle follow
+private _hasSlewInput = vtx_uh60_flir_isSlewing && {_keySlew || {(abs _inputX + abs _inputY) > 0.005}};
+
+// Tracking state machine (per design spec):
+//   FREE    - camera moves freely
+//   GEOLOCK - holds a ground point; slew input DRAGS the point, which stays
+//             locked where the user leaves it
+//   FOLLOW  - tracks a live vehicle; slew input demotes to GEOLOCK at the
+//             current aim; the lock key releases (fnc_setStabilization)
+// NOTE: the engine's getPilotCameraTarget does NOT return the object - the mod
+// patches it into element 2 of its own state variable in fnc_syncPilotCamera,
+// which is the only valid source (#538)
+private _trackedObj = vtx_uh60_flir_pilotCameraTarget param [2, objNull];
+private _inNativeGunnerView = _isGunnerView && {!vtx_uh60_flir_isInScriptedCamera};
+
+// FOLLOW + deliberate input -> GEOLOCK at the point the camera is looking at
+// (the followed vehicle's current position); the slew block below then drags it
+if (!isNull _trackedObj && {_hasSlewInput}) then {
+  private _aimPos = getPosASLVisual _trackedObj;
+  _vehicle setPilotCameraTarget _aimPos;
+  [[], _aimPos] call vtx_uh60_flir_fnc_syncPilotCamera;
+  _trackedObj = objNull;
+};
+
+// Enforcement while NOT receiving deliberate input. The native gunner view
+// (the pilot's fullscreen) renders the ENGINE camera, which neither steers
+// script-set locks nor honors setPilotCameraDirection while a target is
+// assigned - re-asserting the target every frame turns the engine's one-time
+// snap into a follow/hold. Every copilot view renders the mod camera, which
+// fnc_updateCamera aims each frame.
+if (!_hasSlewInput) then {
+  if (!isNull _trackedObj) then {
+    if (_inNativeGunnerView) then {
+      _vehicle setPilotCameraTarget _trackedObj;
+    } else {
+      private _trackOrigin = _vehicle modelToWorldVisualWorld (getPilotCameraPosition _vehicle);
+      _vehicle setPilotCameraDirection (_vehicle vectorWorldToModelVisual (_trackOrigin vectorFromTo getPosASLVisual _trackedObj));
+    };
+  } else {
+    if (_inNativeGunnerView) then {
+      if (vtx_uh60_flir_pilotCameraTarget param [0, false]) then {
+        // Held ground point: re-assert the position captured at lock time (or
+        // by the last drag) from the mod's own state. Re-asserting the
+        // engine's live readback compounded a get/set frame-of-reference
+        // offset every frame and the point drifted away
+        _vehicle setPilotCameraTarget (vtx_uh60_flir_pilotCameraTarget param [1, [0,0,0]]);
+      } else {
+        // Mod state is authoritative: the VANILLA lock action fires on any
+        // input device with its own desynced toggle state - stomp any rogue
+        // engine lock it set, restoring the direction our own release chose
+        // if the rogue lock snapped the camera within the same press
+        if ((getPilotCameraTarget _vehicle) # 0) then {
+          _vehicle setPilotCameraTarget objNull;
+          if (diag_tickTime < (missionNamespace getVariable ["vtx_uh60_flir_lastReleaseTime", -99]) + 1) then {
+            _vehicle setPilotCameraDirection vtx_uh60_flir_lastReleaseDir;
+          };
+        };
+      };
+    };
+  };
+};
+
 if (vtx_uh60_flir_isSlewing) then {
-//systemchat str ["SLEWING", time];
     private _originPos = _vehicle modelToWorldVisualWorld (getPilotCameraPosition _vehicle);
     private _cameraVectorWorld = _vehicle vectorModelToWorld (getPilotCameraDirection _vehicle);
     private _rateY = ([0.04 * vtx_uh60_flir_setting_AimSlewSpeed, 0.08 * vtx_uh60_flir_setting_KeySlewSpeed] select _keySlew) * (vtx_uh60_flir_FOV * 50);
     private _rateX = vtx_uh60_flir_aspectRatio * ([vtx_uh60_flir_setting_AimXFactor, vtx_uh60_flir_setting_KeyXFactor] select _keySlew);
     if (getPilotCameraTarget _vehicle # 0) then {
 
-        // Object track: in gunner view / scripted camera every mouselook twitch
-        // registers as slew, and retargeting here replaced the object lock with
-        // a ground position each frame - the camera never followed. Only
-        // deliberate key slew (or pressing lock again) may break a follow.
-        // Tracked object must come from the mod's own state variable - the
-        // engine's getPilotCameraTarget does not expose it (#538)
+        // Sub-deadzone mouselook twitch while following: keep the follow.
+        // Deliberate input was already demoted to GEOLOCK above (#538)
         if (!isNull (vtx_uh60_flir_pilotCameraTarget param [2, objNull]) && {!_keySlew}) exitWith {};
 
         _cameraVectorWorld = (_originPos vectorFromTo (getPilotCameraTarget _vehicle # 1));
@@ -85,10 +127,14 @@ if (vtx_uh60_flir_isSlewing) then {
         private _intersectResult = [_originPos, _newDir # 0, _newDir # 1] call vtx_uh60_flir_fnc_intersectAtPolar;
         if (!isNil "_intersectResult") then {
             private _intersect = _intersectResult # 0; // slew stays a position lock; object tracking is setStabilization's job
-            if (!_isGunnerView || vtx_uh60_flir_playerIsCopilot) then {_vehicle setPilotCameraTarget _intersect};
-            [getPilotCameraDirection _vehicle, getPilotCameraTarget _vehicle # 1] call vtx_uh60_flir_fnc_syncPilotCamera;
+            // GEOLOCK drag re-targets in EVERY view: the native gunner view is
+            // safe now that the mod's state is authoritative there (it was
+            // excluded before, which is why the pilot could not move a held
+            // point without unlocking first - tester report)
+            _vehicle setPilotCameraTarget _intersect;
+            [getPilotCameraDirection _vehicle, _intersect] call vtx_uh60_flir_fnc_syncPilotCamera;
         } else {
-            if (!_isGunnerView || vtx_uh60_flir_playerIsCopilot) then {_vehicle setPilotCameraTarget objNull};
+            _vehicle setPilotCameraTarget objNull;
             [getPilotCameraDirection _vehicle, objNull] call vtx_uh60_flir_fnc_syncPilotCamera;
         };
     } else {

--- a/addons/uh60_flir/functions/fnc_handleSlew.sqf
+++ b/addons/uh60_flir/functions/fnc_handleSlew.sqf
@@ -30,6 +30,17 @@ if (_isGunnerView) then {
 // get current dir
 (getPilotCameraRotation _vehicle) params ["_azimuth", "_elevation"];
 
+// Active follow: a target set while already inside the gunner view / scripted
+// camera is not steered by the engine, so aim the pilot camera at the tracked
+// object ourselves every frame. NOTE: the engine's getPilotCameraTarget does
+// NOT return the object - the mod patches it into element 2 of its own state
+// variable in fnc_syncPilotCamera, which is the only valid source (#538)
+private _trackedObj = vtx_uh60_flir_pilotCameraTarget param [2, objNull];
+if (!isNull _trackedObj) then {
+  private _trackOrigin = _vehicle modelToWorldVisualWorld (getPilotCameraPosition _vehicle);
+  _vehicle setPilotCameraDirection (_vehicle vectorWorldToModelVisual (_trackOrigin vectorFromTo getPosASLVisual _trackedObj));
+};
+
 // check key slew
 private _inputX = 0;
 private _inputY = 0;
@@ -56,6 +67,14 @@ if (vtx_uh60_flir_isSlewing) then {
     private _rateX = vtx_uh60_flir_aspectRatio * ([vtx_uh60_flir_setting_AimXFactor, vtx_uh60_flir_setting_KeyXFactor] select _keySlew);
     if (getPilotCameraTarget _vehicle # 0) then {
 
+        // Object track: in gunner view / scripted camera every mouselook twitch
+        // registers as slew, and retargeting here replaced the object lock with
+        // a ground position each frame - the camera never followed. Only
+        // deliberate key slew (or pressing lock again) may break a follow.
+        // Tracked object must come from the mod's own state variable - the
+        // engine's getPilotCameraTarget does not expose it (#538)
+        if (!isNull (vtx_uh60_flir_pilotCameraTarget param [2, objNull]) && {!_keySlew}) exitWith {};
+
         _cameraVectorWorld = (_originPos vectorFromTo (getPilotCameraTarget _vehicle # 1));
         private _slewOrigin = (_cameraVectorWorld) call CBA_fnc_vect2Polar;
         private _newDir = [
@@ -63,8 +82,9 @@ if (vtx_uh60_flir_isSlewing) then {
             (_slewOrigin # 2) + (_inputY * _rateY)
         ];
 
-        private _intersect = [_originPos, _newDir # 0, _newDir # 1] call vtx_uh60_flir_fnc_intersectAtPolar;
-        if (!isNil "_intersect") then {
+        private _intersectResult = [_originPos, _newDir # 0, _newDir # 1] call vtx_uh60_flir_fnc_intersectAtPolar;
+        if (!isNil "_intersectResult") then {
+            private _intersect = _intersectResult # 0; // slew stays a position lock; object tracking is setStabilization's job
             if (!_isGunnerView || vtx_uh60_flir_playerIsCopilot) then {_vehicle setPilotCameraTarget _intersect};
             [getPilotCameraDirection _vehicle, getPilotCameraTarget _vehicle # 1] call vtx_uh60_flir_fnc_syncPilotCamera;
         } else {

--- a/addons/uh60_flir/functions/fnc_intersectAtPolar.sqf
+++ b/addons/uh60_flir/functions/fnc_intersectAtPolar.sqf
@@ -1,3 +1,4 @@
+// Returns [intersect position ASL, hit object (objNull for terrain)] or nil on no hit
 params ["_origin","_angleX","_angleY"];
 
 scopeName "return";
@@ -10,6 +11,7 @@ for "_i" from 0 to 15 step 1 do {
   private _endPos = _startPos vectorAdd _vectorIntersect;
   private _intersect = lineIntersectsSurfaces [_startPos, _endPos, (vehicle player)];
   if(count _intersect > 0) then {
-    (_intersect # 0 # 0) breakOut "return";
+    (_intersect # 0) params ["_intersectPos", "", "_hitObject", "_hitParent"];
+    [_intersectPos, [_hitObject, _hitParent] select (!isNull _hitParent)] breakOut "return";
   };
 };

--- a/addons/uh60_flir/functions/fnc_perFrame.sqf
+++ b/addons/uh60_flir/functions/fnc_perFrame.sqf
@@ -56,10 +56,9 @@ if (_bootTime > -1) then {
   };
 };
 
-if (
-  vtx_uh60_flir_isPipHidden
-  && {[cameraView != "GUNNER", !vtx_uh60_flir_isInScriptedCamera] select vtx_uh60_flir_setting_useScriptedCamera}
-) exitWith {};
+// (Use Scripted Camera setting removed - its off-mode selected the copilot
+// turret optics, disabled until the model gains a View - Gunner LOD, #560)
+if (vtx_uh60_flir_isPipHidden && {!vtx_uh60_flir_isInScriptedCamera}) exitWith {};
 
 [_vehicle] call vtx_uh60_flir_fnc_updateCamera;
 _this call vtx_uh60_flir_fnc_updateUIValues;

--- a/addons/uh60_flir/functions/fnc_perSecond.sqf
+++ b/addons/uh60_flir/functions/fnc_perSecond.sqf
@@ -8,7 +8,9 @@
 
 params ["_vehicle"];
 
-if (vtx_uh60_flir_setting_useScriptedCamera && vtx_uh60_flir_setting_animateTurret && {local _vehicle}) then {
+// (Use Scripted Camera setting removed - the FLIR ball always animates from
+// the camera while the copilot turret optics are disabled, #560)
+if (vtx_uh60_flir_setting_animateTurret && {local _vehicle}) then {
   [_vehicle] call vtx_uh60_flir_fnc_syncAnimation;
 };
 

--- a/addons/uh60_flir/functions/fnc_scriptedCamera.sqf
+++ b/addons/uh60_flir/functions/fnc_scriptedCamera.sqf
@@ -36,6 +36,44 @@ if (_show) then {
   [vtx_uh60_flir_pipEffect, false] call vtx_uh60_flir_fnc_setVisionMode;
   vtx_uh60_flir_isInScriptedCamera = true;
 
+  // Vanilla user actions do not fire (and inputAction reads 0) while a
+  // cameraEffect camera is active, so hook the raw input and map it through
+  // the player's actual binding for the lock action. Mouse buttons appear in
+  // actionKeys as 65536 + button, so both device paths are needed (#538)
+  if (isNil "vtx_uh60_flir_fullscreenKeyEH") then {
+    vtx_uh60_flir_lastLockPress = 0;
+    private _fire = {
+      if (diag_tickTime > vtx_uh60_flir_lastLockPress + 0.3) then {
+        vtx_uh60_flir_lastLockPress = diag_tickTime;
+        [
+          AGLToASL positionCameraToWorld [0, 0, 0],
+          AGLToASL positionCameraToWorld [0, 0, 5000]
+        ] call vtx_uh60_flir_fnc_setStabilization;
+      };
+    };
+    vtx_uh60_flir_fullscreenLockFire = _fire;
+    vtx_uh60_flir_fullscreenKeyEH = (findDisplay 46) displayAddEventHandler ["KeyDown", {
+      params ["", "_key"];
+      if (!vtx_uh60_flir_isInScriptedCamera) exitWith {false};
+      if (missionNamespace getVariable ["vtx_uh60_ui_showDebugMessages", false]) then {
+        systemChat format ["FS KeyDown %1 (lock keys %2)", _key, actionKeys "vehLockTurretView"];
+      };
+      if (_key in (actionKeys "vehLockTurretView")) then {call vtx_uh60_flir_fullscreenLockFire; true} else {false};
+    }];
+    vtx_uh60_flir_fullscreenMouseEH = (findDisplay 46) displayAddEventHandler ["MouseButtonDown", {
+      params ["", "_button"];
+      if (!vtx_uh60_flir_isInScriptedCamera) exitWith {false};
+      if (missionNamespace getVariable ["vtx_uh60_ui_showDebugMessages", false]) then {
+        systemChat format ["FS MouseDown %1 -> %2 (lock keys %3)", _button, 65536 + _button, actionKeys "vehLockTurretView"];
+      };
+      if ((65536 + _button) in (actionKeys "vehLockTurretView")) then {call vtx_uh60_flir_fullscreenLockFire; true} else {false};
+    }];
+    if (missionNamespace getVariable ["vtx_uh60_ui_showDebugMessages", false]) then {
+      systemChat format ["FS lock hooks installed: key EH %1, mouse EH %2, lock keys %3",
+        vtx_uh60_flir_fullscreenKeyEH, vtx_uh60_flir_fullscreenMouseEH, actionKeys "vehLockTurretView"];
+    };
+  };
+
 } else {
 
   vtx_uh60_flir_camera cameraEffect ["terminate", "back"];
@@ -49,6 +87,15 @@ if (_show) then {
     // Fix pip black screen
     vtx_uh60_flir_camera cameraEffect ["internal", "BACK", "vtx_uh60_flir_feed"];
     "vtx_uh60_flir_feed" setPiPEffect vtx_uh60_flir_pipEffect;
+  };
+
+  if (!isNil "vtx_uh60_flir_fullscreenKeyEH") then {
+    (findDisplay 46) displayRemoveEventHandler ["KeyDown", vtx_uh60_flir_fullscreenKeyEH];
+    vtx_uh60_flir_fullscreenKeyEH = nil;
+  };
+  if (!isNil "vtx_uh60_flir_fullscreenMouseEH") then {
+    (findDisplay 46) displayRemoveEventHandler ["MouseButtonDown", vtx_uh60_flir_fullscreenMouseEH];
+    vtx_uh60_flir_fullscreenMouseEH = nil;
   };
 
   vtx_uh60_flir_isInScriptedCamera = false;

--- a/addons/uh60_flir/functions/fnc_setStabilization.sqf
+++ b/addons/uh60_flir/functions/fnc_setStabilization.sqf
@@ -44,6 +44,12 @@ if (!isNull _trackObj) exitWith {
   );
   hct_vehicle setPilotCameraTarget objNull;
   hct_vehicle setPilotCameraDirection _dir;
+  // remember the released direction: if the VANILLA lock action re-locks after
+  // us on the same press (its toggle state is desynced; HOTAS bindings bypass
+  // the display-level consume hooks), the per-frame authority in fnc_handleSlew
+  // stomps the rogue lock and restores this direction
+  vtx_uh60_flir_lastReleaseDir = _dir;
+  vtx_uh60_flir_lastReleaseTime = diag_tickTime;
   [[], objNull] call vtx_uh60_flir_fnc_syncPilotCamera;
   if (missionNamespace getVariable ["vtx_uh60_ui_showDebugMessages", false]) then {
     systemChat format ["FLIR lock: released %1", typeOf _trackObj];
@@ -116,6 +122,8 @@ if (!isNull _trackTarget) then {
 
     hct_vehicle setPilotCameraTarget objNull;
     hct_vehicle setPilotCameraDirection _dir;
+    vtx_uh60_flir_lastReleaseDir = _dir;
+    vtx_uh60_flir_lastReleaseTime = diag_tickTime;
     [[], objNull] call vtx_uh60_flir_fnc_syncPilotCamera;
 
   } else {

--- a/addons/uh60_flir/functions/fnc_setStabilization.sqf
+++ b/addons/uh60_flir/functions/fnc_setStabilization.sqf
@@ -28,15 +28,57 @@ vtx_uh60_flir_pilotCameraTarget params ["_isTracking", "", "_trackObj"];
 
 private _originPos = hct_vehicle modelToWorldVisualWorld (getPilotCameraPosition hct_vehicle);
 private _cameraVectorWorld = hct_vehicle vectorModelToWorld (getPilotCameraDirection hct_vehicle);
-private _slewOrigin = (_cameraVectorWorld) call CBA_fnc_vect2Polar;
-private _intersect = [_originPos, _slewOrigin # 1, _slewOrigin # 2] call vtx_uh60_flir_fnc_intersectAtPolar;
 
-if (isNil "_intersect") exitWith {};
+private _intersectResult = if (_camPosASL isNotEqualTo []) then {
+    // Scripted camera passes its true view ray. The pilot camera can trail a
+    // moving target in fullscreen, so raycast what the player actually sees;
+    // otherwise moving vehicles can only ever be locked from PiP (#538)
+    private _hits = lineIntersectsSurfaces [_camPosASL, _tgtPosASL, hct_vehicle];
+    if (_hits isEqualTo []) then {nil} else {
+        (_hits # 0) params ["_pos", "", "_obj", "_parent"];
+        [_pos, [_obj, _parent] select (!isNull _parent)]
+    };
+} else {
+    private _slewOrigin = (_cameraVectorWorld) call CBA_fnc_vect2Polar;
+    [_originPos, _slewOrigin # 1, _slewOrigin # 2] call vtx_uh60_flir_fnc_intersectAtPolar
+};
 
-private _nearObjects = nearestObjects [ASLtoAGL _intersect, ["Land", "Air", "Ship"], 5];
-if (_nearObjects isNotEqualTo []) then {
-  hct_vehicle setPilotCameraTarget (_nearObjects # 0);
-  [[], _intersect, (_nearObjects # 0)] call vtx_uh60_flir_fnc_syncPilotCamera;
+if (isNil "_intersectResult") exitWith {};
+_intersectResult params ["_intersect", "_hitObject"];
+
+// Prefer the object the ray actually hit — a proximity search around the impact
+// point misses large vehicles (origin > 5 m from the hull) and aircraft entirely,
+// because a near-miss ray lands on terrain far behind the target (#538)
+private _trackTarget = objNull;
+if (!isNull _hitObject) then {
+  private _hitVehicle = vehicle _hitObject; // crew hit resolves to their vehicle
+  if (_hitVehicle isKindOf "LandVehicle" || {_hitVehicle isKindOf "Air"} || {_hitVehicle isKindOf "Ship"} || {_hitVehicle isKindOf "Man"}) then {
+    _trackTarget = _hitVehicle;
+  };
+};
+// Fallback: boresight cone search on VISUAL positions. A raycast tests sim
+// positions, which trail the rendered hull on movers - so aiming dead-on at a
+// moving vehicle can still miss. Pick the candidate closest to the view axis
+// within a small cone instead (#538 fullscreen lock)
+if (isNull _trackTarget) then {
+  private _rayOrigin = [_originPos, _camPosASL] select (_camPosASL isNotEqualTo []);
+  private _rayDir = if (_camPosASL isNotEqualTo []) then {_camPosASL vectorFromTo _tgtPosASL} else {vectorNormalized _cameraVectorWorld};
+  private _coneCos = cos 2.5; // half-cone in degrees
+  private _bestDot = _coneCos;
+  {
+    if (_x != hct_vehicle && {vehicle _x != hct_vehicle}) then {
+      private _dot = _rayDir vectorDotProduct (_rayOrigin vectorFromTo getPosASLVisual _x);
+      if (_dot > _bestDot) then {_bestDot = _dot; _trackTarget = _x};
+    };
+  } forEach (hct_vehicle nearEntities [["LandVehicle", "Air", "Ship"], 5000]);
+};
+if (missionNamespace getVariable ["vtx_uh60_ui_showDebugMessages", false]) then {
+  systemChat format ["FLIR lock: rayHit=%1 target=%2", typeOf _hitObject, typeOf _trackTarget];
+};
+
+if (!isNull _trackTarget) then {
+  hct_vehicle setPilotCameraTarget _trackTarget;
+  [[], _intersect, _trackTarget] call vtx_uh60_flir_fnc_syncPilotCamera;
 } else {
   if ((getPilotCameraTarget hct_vehicle) # 0) then {
 

--- a/addons/uh60_flir/functions/fnc_setStabilization.sqf
+++ b/addons/uh60_flir/functions/fnc_setStabilization.sqf
@@ -23,11 +23,33 @@ params [
 
 //if (vtx_uh60_flir_playerIsPilot && {vtx_uh60_flir_isCopilotInGunnerView}) exitWith {false};
 
-vtx_uh60_flir_pilotCameraTarget params ["_isTracking", "", "_trackObj"];
-
+private _trackObj = vtx_uh60_flir_pilotCameraTarget param [2, objNull];
 
 private _originPos = hct_vehicle modelToWorldVisualWorld (getPilotCameraPosition hct_vehicle);
 private _cameraVectorWorld = hct_vehicle vectorModelToWorld (getPilotCameraDirection hct_vehicle);
+
+// The lock key is a toggle: with an object track active the camera is being
+// steered onto the target, so a fresh boresight ray always re-hits the same
+// vehicle and silently re-locked it. Break the lock instead - in fullscreen
+// there is no other way out, since mouselook deliberately does not stomp
+// tracks (#538 follow-up)
+if (!isNull _trackObj) exitWith {
+  private _dir = hct_vehicle vectorWorldToModelVisual (
+    [
+      _cameraVectorWorld,
+      ATLtoASL positionCameraToWorld [0,0,0]
+      vectorFromTo
+      ATLtoASL positionCameraToWorld [0,0,1000]
+    ] select vtx_uh60_flir_isInScriptedCamera
+  );
+  hct_vehicle setPilotCameraTarget objNull;
+  hct_vehicle setPilotCameraDirection _dir;
+  [[], objNull] call vtx_uh60_flir_fnc_syncPilotCamera;
+  if (missionNamespace getVariable ["vtx_uh60_ui_showDebugMessages", false]) then {
+    systemChat format ["FLIR lock: released %1", typeOf _trackObj];
+  };
+  true
+};
 
 private _intersectResult = if (_camPosASL isNotEqualTo []) then {
     // Scripted camera passes its true view ray. The pilot camera can trail a

--- a/addons/uh60_flir/functions/fnc_syncPilotCamera.sqf
+++ b/addons/uh60_flir/functions/fnc_syncPilotCamera.sqf
@@ -22,41 +22,32 @@ params ["_rot_dir", "_target", ["_targetObject", objNull], ["_immediate", false]
   };
 #endif
 
+// Apply locally ALWAYS, then forward to the other pilot when they are a
+// player. This used to be either/or: with a human in the other seat the
+// originating client only sent and never updated its own
+// vtx_uh60_flir_pilotCameraTarget (the sole writer is below), so the mod-side
+// state that handleSlew/updateCamera/setStabilization now treat as
+// authoritative went stale on the locker's own machine - fullscreen locks
+// were stomped as "rogue" next frame, the copilot's own view never followed,
+// and the lock toggle could not release. Only ever exercised with an AI or
+// empty other seat before (#538 MP follow-up)
 if (_propagate && vtx_uh60_flir_otherPilotIsPlayer) then {
   [_rot_dir, _target, _targetObject, _immediate, false] remoteExecCall ["vtx_uh60_flir_fnc_syncPilotCamera", vtx_uh60_flir_otherPilot, false];
-} else {
-    params ["_rot_dir", "_target", "_targetObject"];
-  switch (count _rot_dir) do {
-    case 0: {};
-    case 2: {
-      hct_vehicle setPilotCameraRotation _rot_dir;
-
-#ifdef DEBUG_MODE_FULL
-  if !(getPilotCameraTarget hct_vehicle # 0) then {
-    //systemChat str "Rotation";
-  };
-#endif
-
-    };
-    case 3: {
-      hct_vehicle setPilotCameraDirection _rot_dir;
-
-#ifdef DEBUG_MODE_FULL
-  if !(getPilotCameraTarget hct_vehicle # 0) then {
-    //systemChat str "Direction";
-  };
-#endif
-
-      };
-  };
-  if (!isNull _targetObject) then {
-    hct_vehicle setPilotCameraTarget _targetObject;
-  } else {
-    hct_vehicle setPilotCameraTarget _target;
-  };
-  vtx_uh60_flir_pilotCameraTarget = getPilotCameraTarget hct_vehicle;
-  if (vtx_uh60_flir_pilotCameraTarget # 0) then {
-    vtx_uh60_flir_pilotCameraTarget set [2, _targetObject];
-  };
 };
+
+switch (count _rot_dir) do {
+  case 0: {};
+  case 2: {hct_vehicle setPilotCameraRotation _rot_dir};
+  case 3: {hct_vehicle setPilotCameraDirection _rot_dir};
+};
+if (!isNull _targetObject) then {
+  hct_vehicle setPilotCameraTarget _targetObject;
+} else {
+  hct_vehicle setPilotCameraTarget _target;
+};
+vtx_uh60_flir_pilotCameraTarget = getPilotCameraTarget hct_vehicle;
+if (vtx_uh60_flir_pilotCameraTarget # 0) then {
+  vtx_uh60_flir_pilotCameraTarget set [2, _targetObject];
+};
+
 true

--- a/addons/uh60_flir/functions/fnc_updateCamera.sqf
+++ b/addons/uh60_flir/functions/fnc_updateCamera.sqf
@@ -17,6 +17,14 @@ params ["_vehicle"];
 private _camPosASL = hct_vehicle modelToWorldVisualWorld vtx_uh60_flir_camPos;
 vtx_uh60_flir_camera setPosASL _camPosASL;
 getPilotCameraTarget _vehicle params ["_isTracking", "_tgtPosASL", ""];
+// Object follow: the engine's target position is a static snapshot for
+// script-set object locks - aim at the live object from the mod's own state
+// variable instead (element 2, patched in fnc_syncPilotCamera) (#538)
+private _trackedObj = vtx_uh60_flir_pilotCameraTarget param [2, objNull];
+if (!isNull _trackedObj) then {
+  _isTracking = true;
+  _tgtPosASL = getPosASLVisual _trackedObj;
+};
 if (_isTracking) then {
   if (vtx_uh60_flir_isInScriptedCamera) then { // Fix laser target wandering off
     private _laserTarget = laserTarget hct_vehicle;

--- a/addons/uh60_flir/initKeybinds.sqf
+++ b/addons/uh60_flir/initKeybinds.sqf
@@ -1,6 +1,15 @@
 //addUserActionEventHandler ["transportNightVision", "Activate", vtx_uh60_flir_fnc_keyVisionMode];
 addUserActionEventHandler ["vehLockTurretView", "Activate", {
-  if (!vtx_uh60_flir_controllable || {cameraView == "GUNNER"}) exitWith {};
+  // "Fullscreen FLIR" for the DRIVER is the vanilla pilot-camera view, which is
+  // cameraView "GUNNER" - so the gunner-view guard must let the pilot and the
+  // copilot through and block only real door gunners, whose T key keeps its
+  // vanilla turret-lock meaning. The mod's scripted camera has its own hooks
+  // (fnc_scriptedCamera) - exit here to avoid double-triggering (#538)
+  if (
+    !vtx_uh60_flir_controllable
+    || {vtx_uh60_flir_isInScriptedCamera}
+    || {cameraView == "GUNNER" && {!(vtx_uh60_flir_playerIsCopilot || vtx_uh60_flir_playerIsPilot)}}
+  ) exitWith {};
   if (vtx_uh60_flir_isInScriptedCamera) then {
     [
         AGLToASL positionCameraToWorld [0, 0, 0],

--- a/addons/uh60_flir/initKeybinds.sqf
+++ b/addons/uh60_flir/initKeybinds.sqf
@@ -20,6 +20,39 @@ addUserActionEventHandler ["vehLockTurretView", "Activate", {
   };
 }];
 
+// The pilot's fullscreen FLIR is the ENGINE's gunner view, where the vanilla
+// lock action also fires and keeps its own toggle state - desynced from the
+// mod's script-set locks: on the second press the mod releases while vanilla,
+// believing nothing was locked, immediately re-locks natively and snaps the
+// camera away (tester report, #559). Consume the key/button at display level
+// there and route it through setStabilization only. Mouse buttons appear in
+// actionKeys as 65536 + button, same as the scripted-camera hooks (#538)
+vtx_uh60_flir_lastLockPress = 0;
+vtx_uh60_flir_nativeLockFire = {
+  if (diag_tickTime > vtx_uh60_flir_lastLockPress + 0.3) then {
+    vtx_uh60_flir_lastLockPress = diag_tickTime;
+    [] call vtx_uh60_flir_fnc_setStabilization;
+  };
+};
+vtx_uh60_flir_nativeLockCondition = {
+  cameraView == "GUNNER"
+  && {!vtx_uh60_flir_isInScriptedCamera}
+  && {missionNamespace getVariable ["vtx_uh60_flir_controllable", false]}
+  && {vtx_uh60_flir_playerIsPilot}
+};
+[{!isNull findDisplay 46}, {
+  (findDisplay 46) displayAddEventHandler ["KeyDown", {
+    params ["", "_key"];
+    if !(call vtx_uh60_flir_nativeLockCondition) exitWith {false};
+    if (_key in (actionKeys "vehLockTurretView")) then {call vtx_uh60_flir_nativeLockFire; true} else {false};
+  }];
+  (findDisplay 46) displayAddEventHandler ["MouseButtonDown", {
+    params ["", "_button"];
+    if !(call vtx_uh60_flir_nativeLockCondition) exitWith {false};
+    if ((65536 + _button) in (actionKeys "vehLockTurretView")) then {call vtx_uh60_flir_nativeLockFire; true} else {false};
+  }];
+}] call CBA_fnc_waitUntilAndExecute;
+
 addUserActionEventHandler ["showMap", "Activate", {
   if (visibleMap || !vtx_uh60_flir_isInScriptedCamera) exitWith {};
   vtx_uh60_flir_scriptedCameraToMap = true;

--- a/addons/uh60_flir/initSettings.sqf
+++ b/addons/uh60_flir/initSettings.sqf
@@ -1,11 +1,6 @@
-[
-    "vtx_uh60_flir_setting_useScriptedCamera", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
-    "CHECKBOX", // setting type
-    [LSTRING(UseScriptedCamera), LSTRING(UseScriptedCamera_Tooltip)], // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
-    ["UH-60M", "FLIR"], // Pretty name of the category where the setting can be found. Can be stringtable entry.
-    true, // data for this setting: [min, max, default, number of shown trailing decimals]
-    nil // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
-] call CBA_fnc_addSetting;
+// "Use Scripted Camera" setting removed: its off-mode selected the copilot
+// turret optics, disabled until the model gains a View - Gunner LOD (#560).
+// Restore the setting together with the optics if the mode returns.
 
 [
     "vtx_uh60_flir_setting_animateTurret", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.

--- a/addons/uh60_flir/stringtable.xml
+++ b/addons/uh60_flir/stringtable.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project name="VTX">
     <Package name="UH60_FLIR">
-        <Key ID="STR_VTX_UH60_FLIR_UseScriptedCamera">
-            <English>Use Scripted Camera</English>
-        </Key>
-        <Key ID="STR_VTX_UH60_FLIR_UseScriptedCamera_Tooltip">
-            <English>Use scripted camera for FLIR view instead of pilot camera and turret optics.</English>
-        </Key>
         <Key ID="STR_VTX_UH60_FLIR_AimSlewBlockMouse">
             <English>FLIR Aim Slew Block Mouse</English>
         </Key>


### PR DESCRIPTION
## What this fixes

- **Copilot cockpit is back (#556).** The missing upper console and interior in the copilot seat are fixed on every variant, get-in animations play again, and copilots are no longer invisible. The copilot's built-in optics view is disabled for now (it needs a model update to work correctly) — FLIR use through the MFDs and fullscreen camera is unchanged.
- **FLIR locks onto vehicles (#538).** The lock key now works in every view — MFD screen, pilot fullscreen, and copilot fullscreen — and locks onto vehicles reliably, including moving and flying targets. Once locked, the camera follows the target; look around freely without losing the lock, and break it with a slew key or by pressing lock again. Aiming at empty ground still ground-stabilizes. Door gunner controls are untouched.

## Technical notes (for review)

- #556: the 0.7.6.9 optics turret makes the engine render the View - Gunner LOD, which `vtx_uh60.p3d` does not have, causing a resolution-LOD fallback with a gutted interior. Both `copilotFLIR.hpp` include sites now use `copilot.hpp`; `soundAttenuationTurret` carried over; `copilotFLIR.hpp` retained with optics commented for restoration once the model gains a 1000 LOD (copy of 1100 suffices — this would also fix the "not visible from crewed guns" report in the issue thread).
- #538: guard fix in `initKeybinds.sqf` (gunner view = pilot's fullscreen); raw `KeyDown`/`MouseButtonDown` hooks in `fnc_scriptedCamera.sqf` (vanilla actions and `inputAction` are both suppressed under `cameraEffect`); `fnc_intersectAtPolar` returns the hit object; boresight cone over `getPosASLVisual` in `fnc_setStabilization`; per-frame steering in `fnc_handleSlew`/`fnc_updateCamera` off the mod's own target state (`getPilotCameraTarget` does not expose script-set objects); mouselook no longer re-targets an object track. Lock diagnostics behind Show Debug Messages.

## Validation
> The **Use Scripted Camera** addon setting is removed by this PR: its disabled mode selected the copilot turret optics, which are unavailable until the model gains the View - Gunner LOD (#560). The scripted camera is the only copilot camera path for now; the setting returns with the optics if the choice is still wanted.


Tested in-game across iterative builds: copilot console + get-in animation on all variants; lock-and-follow on moving targets from PiP, pilot fullscreen, and copilot scripted camera; geolock, slew, and door-gunner behavior unchanged.

Closes #538, 
Keep #556 open pending additional LOD added


