### PR TITLE
Fix ALT hold increase/decrease keybind interaction names

### DIFF
--- a/addons/uh60_fd/Armakeybinds.hpp
+++ b/addons/uh60_fd/Armakeybinds.hpp
@@ -46,7 +46,7 @@ class CfgUserActions {
   class Vtx_ALT_Increase: Vtx_RALT_Toggle {
     displayName = "Increase ALT Hold";
     tooltip = "Increases the Barometric Altitude Hold Mode";
-    onActivate = "[hct_vehicle, ['misc', format ['KnobFD%1_BALT', ['Left', 'Right'] select (driver hct_vehicle == hct_player)]], 1] call hct_interaction_fnc_scriptedInteract;";		// _this is always true.
+    onActivate = "[hct_vehicle, ['misc', format ['KnobFD%1_ALT', ['Left', 'Right'] select (driver hct_vehicle == hct_player)]], 1] call hct_interaction_fnc_scriptedInteract;";		// _this is always true.
   };
   class Vtx_IAS_Increase: Vtx_RALT_Toggle {
     displayName = "Increase IAS Hold";
@@ -71,7 +71,7 @@ class CfgUserActions {
   class Vtx_ALT_Decrease: Vtx_RALT_Toggle {
     displayName = "Decrease ALT Hold";
     tooltip = "Decreases the Barometric Altitude Hold Mode";
-    onActivate = "[hct_vehicle, ['misc', format ['KnobFD%1_BALT', ['Left', 'Right'] select (driver hct_vehicle == hct_player)]], -1] call hct_interaction_fnc_scriptedInteract;";		// _this is always true.
+    onActivate = "[hct_vehicle, ['misc', format ['KnobFD%1_ALT', ['Left', 'Right'] select (driver hct_vehicle == hct_player)]], -1] call hct_interaction_fnc_scriptedInteract;";		// _this is always true.
   };
   class Vtx_IAS_Decrease: Vtx_RALT_Toggle {
     displayName = "Decrease IAS Hold";


### PR DESCRIPTION
﻿## Summary
- Mod-side half of #547: the ALT-hold increase/decrease keybinds formatted the interaction name as `KnobFD%1_BALT`, but the cockpit interaction classes are `KnobFDLeft_ALT` / `KnobFDRight_ALT`, so the scripted interaction could never resolve. No `KnobFD*_BALT` class exists anywhere in the repo.
- Two-line fix in `addons/uh60_fd/Armakeybinds.hpp`; no other behavior touched.

## Testing
- Verified in-game (2026-08-17): ALT inc/dec binds now turn the ALT select knob and change the hold value from both seats, matching the RALT/ALTP/IAS/HDG binds; RPT clean of interaction-resolution errors.

## Remaining framework-side issue
First use of any FD inc/dec bind in a session can still error from `hct_interaction_fnc_knobAnimate` reading `hct_interaction_knobHolding` via a non-lazy `&&` before it is defined. That fix belongs in the Interaction-Framework repo and is tracked as the second half of #547.
