### PR TITLE
Guard laser code lookup against out-of-range MFD values

### DIFF
--- a/addons/uh60_weapons/functions/fnc_getLaserCode.sqf
+++ b/addons/uh60_weapons/functions/fnc_getLaserCode.sqf
@@ -6,8 +6,12 @@ private _pylon = switch (_type) do {
 	case "ALT CHAN": {USERMFDV_ALT_CH};
 	case "LRFD": {USERMFDV_LRFD};
 	case "LST": {USERMFDV_LST};
+	default {-1};
 };
-private _index = getUserMFDValue _vehicle select _pylon;
-if (_index == -1) exitWith {1111};
+if (_pylon == -1) exitWith {1111};
+
+// the MFD value is user-driven and can be outside the code table (#436)
+private _index = floor (getUserMFDValue _vehicle select _pylon);
+if (_index < 0 || {_index >= count vtx_uh60_weapons_laserCodes}) exitWith {1111};
 
 vtx_uh60_weapons_laserCodes # _index;


### PR DESCRIPTION
## Summary
Fixes #436: `fnc_getLaserCode` only guarded `_index == -1`, then indexed the six-entry laser code table unchecked, producing a zero-divisor script error whenever the user-driven MFD value fell outside 0-5. The index is now floored and bounds-checked, and an unmatched `_type` (previously a nil `_pylon`, which crashed the select) falls back to the 1111 default.

## Testing
Verified in-game (2026-08-17): Hellfire lock achieved on all channels A-F; mashing the channel controls past both ends of the code list produces no script errors; RPT clean of getLaserCode/zero-divisor entries.