### PR TITLE
Fix hoist ACE action name and remove dead config duplicate

### DIFF
--- a/addons/uh60_hoist/ACE_Actions.sqf
+++ b/addons/uh60_hoist/ACE_Actions.sqf
@@ -1,7 +1,7 @@
 private _displayName = localize LSTRING(RescueHoist);
 private _condition = {[_player] call vtx_uh60_hoist_fnc_canControlHoist || {[_player] call vtx_uh60_hoist_fnc_canMoveHeliToHook}};
 private _statement = {};
-private _action = ["vtx_hoist_action","Rescue Hoist","z\vtx\addons\uh60_hoist\data\ui\iconHook.paa", _statement, _condition] call ace_interact_menu_fnc_createAction;
+private _action = ["vtx_hoist_action", _displayName, "z\vtx\addons\uh60_hoist\data\ui\iconHook.paa", _statement, _condition] call ace_interact_menu_fnc_createAction;
 ["vtx_H60_base", 1, ["ACE_SelfActions"], _action, true] call ace_interact_menu_fnc_addActionToClass;
 
 _displayName = localize LSTRING(DeployHook);
@@ -29,7 +29,7 @@ _action = ["vtx_hoist_MoveToHook", _displayName, "", _statement, _condition] cal
 ["vtx_H60_base", 1, ["ACE_SelfActions", "vtx_hoist_action"], _action, true] call ace_interact_menu_fnc_addActionToClass;
 
 _displayName = localize LSTRING(RaiseHookToHeli);
-_condition = {[player] call vtx_uh60_hoist_fnc_canControlHoist && [_target] call vtx_uh60_hoist_fnc_isHoistReady};
+_condition = {[_player] call vtx_uh60_hoist_fnc_canControlHoist && [_target] call vtx_uh60_hoist_fnc_isHoistReady};
 _statement = vtx_uh60_hoist_fnc_raiseHookToHeli;
 _action = ["vtx_hoist_RaiseHookToHeli", _displayName, "", _statement, _condition] call ace_interact_menu_fnc_createAction;
 ["vtx_H60_base", 1, ["ACE_SelfActions", "vtx_hoist_action"], _action, true] call ace_interact_menu_fnc_addActionToClass;

--- a/addons/uh60_hoist/config/cfgVehicles.hpp
+++ b/addons/uh60_hoist/config/cfgVehicles.hpp
@@ -1,51 +1,9 @@
 class CfgVehicles
 {
-    /* These overwrite inherited actions for some reason
-    class Heli_Transport_01_base_F;
-    class vtx_H60_base: Heli_Transport_01_base_F {
-        class ACE_SelfActions {
-            class VTX_Hoist {
-                displayName = "Hoist";
-                icon = "z\vtx\addons\uh60_hoist\data\ui\iconHook.paa";
-                class VTX_Hoist_DeployHook {
-                    displayName = "Deploy Hook";
-                    condition = "call vtx_uh60_hoist_fnc_canDeployHook";
-                    statement = "call vtx_uh60_hoist_fnc_deployHook";
-                };
-                class VTX_Hoist_SecureHook {
-                    displayName = "Secure Hook";
-                    condition = "call vtx_uh60_hoist_fnc_canSecureHook";
-                    statement = "call vtx_uh60_hoist_fnc_secureHook";
-                };
-                class VTX_Hoist_PullIntoHeli {
-                    displayName = "Pull In Hook Occupant";
-                    condition = "call vtx_uh60_hoist_fnc_canRecoverPerson";
-                    statement = "call vtx_uh60_hoist_fnc_recoverPerson";
-                };
-                class VTX_Hoist_MoveHeliToHook {
-                    displayName = "Move To Hook";
-                    condition = "[_player] call vtx_uh60_hoist_fnc_canMoveHeliToHook";
-                    statement = "[_player] call vtx_uh60_hoist_fnc_moveHeliToHook";
-                };
-                class VTX_Hoist_RaiseHookToHeli {
-                    displayName = "Raise Hook To Heli";
-                    condition = "call vtx_uh60_hoist_fnc_isHoistReady";
-                    statement = "call vtx_uh60_hoist_fnc_raiseHookToHeli";
-                };
-                class VTX_Hoist_LowerHookToGround {
-                    displayName = "Lower Hook To Ground";
-                    condition = "call vtx_uh60_hoist_fnc_isHoistReady";
-                    statement = "call vtx_uh60_hoist_fnc_lowerHookToGround";
-                };
-                class VTX_Hoist_Working {
-                    displayName = "Working...";
-                    condition = "!(call vtx_uh60_hoist_fnc_isHoistReady)";
-                    statement = "";
-                };
-            };
-        };
-    };
-    */
+    // Hoist self-actions are registered script-side in ACE_Actions.sqf
+    // (ace_interact_menu_fnc_addActionToClass): a config ACE_SelfActions
+    // block on vtx_H60_base would overwrite inherited actions instead of
+    // merging with them.
 
     class Man;
     class CAManBase: Man {


### PR DESCRIPTION
## Summary
- The parent Rescue Hoist self-action computed its localized display name but then passed a hardcoded English literal to `createAction`; it now uses the localized name (no visible change in English, fixes other locales).
- The RaiseHookToHeli condition used `player` where every sibling action uses the ACE-provided `_player`.
- Deleted the long-dead commented-out config-side `ACE_SelfActions` block. Script-side registration (`ace_interact_menu_fnc_addActionToClass`) is the intended single source - a config block on `vtx_H60_base` would overwrite inherited actions instead of merging - and a short comment now records that rationale in the config.

## Testing
Verified in-game (2026-08-17): all hoist self-interact entries present and correctly gated per seat; deploy / lower / raise / secure cycle works; Attach/Detach Hook on the hook object unchanged; RPT clean of new errors.