### PR TITLE
Remove debug spam from FLIR auto-scan and engine EH

### DIFF
--- a/addons/uh60_engine/functions/fnc_engineEH.sqf
+++ b/addons/uh60_engine/functions/fnc_engineEH.sqf
@@ -6,9 +6,6 @@
  * params (array)[(object) vehicle, (bool) turnedOn]
  */
 
-/*
- diag_log format ["%1: engine EH", time];
-*/
 params ["_vehicle", "_turnedOn", ["_lever","throttle"], "_animEndState", "_animName"];
 
 if(_turnedOn) then {

--- a/addons/uh60_flir/functions/fnc_autoScanPattern.sqf
+++ b/addons/uh60_flir/functions/fnc_autoScanPattern.sqf
@@ -12,8 +12,6 @@ private _startTime = _vehicle getVariable ["vtx_uh60_flir_fnc_lstTrackStartTime"
 
 //track to start position
 if (_startTime > cba_missionTime) exitWith {
-	private _setupProgress = (5 - (_startTime - cba_missionTime)) / 5;
-	systemChat str ["SETTING UP", _setupProgress];
 	((getPilotCameraRotation _vehicle) apply {deg _x}) params ["_yaw", "_pitch"];
 
 	([_yaw, _pitch] vectorDiff [_barWidth, 0]) params ["_yawDiff", "_pitchDiff"];
@@ -29,7 +27,6 @@ if (_startTime > cba_missionTime) exitWith {
 		rad (_newYaw),
 		rad (_newPitch)
 	];
-	// systemChat str ["SETTING UP", round _setupProgress, round _yaw, round _pitch];
 };
 
 private _timeElapsed = cba_missionTime - _startTime;
@@ -40,7 +37,6 @@ private _barProgress = (_bars - (_barTimeTotal * _currentBar));
 private _transitionAdjustment = 0;
 if (_barProgress > _barTime) then {
 	private _transitionProgress = (_barProgress - _barTime) / _transitionTime;
-	// systemChat str ["TRANSIT", _transitionProgress];
 	_barProgress = _barProgress min _barTime;
 	_transitionAdjustment = (_barHeight * _transitionProgress);
 	if (_currentBar + 1 == _barCount) then {


### PR DESCRIPTION
## Summary
- `fnc_autoScanPattern` ran a live `systemChat` every frame during LST scan setup, spamming SETTING UP lines into chat for the whole setup phase; removed it along with its two commented-out siblings and the now-unused progress calculation.
- `fnc_engineEH`: removed the inert commented-out `diag_log` remnant.
Pure deletions; no logic changed.

## Testing
Verified in-game (2026-08-17): no chat messages during LST auto-scan, scan pattern visually unchanged (slew to start, four-bar sweep), engines start clean, RPT free of new errors.