### PR TITLE
Re-index HIDDENSELECTION_EM_* defines to match the selections array

### DIFF
--- a/addons/main/script_macros.hpp
+++ b/addons/main/script_macros.hpp
@@ -153,14 +153,15 @@ if (_unit isNotEqualTo (driver _vehicle) && {(_vehicle unitTurret _unit) isNotEq
 #define HIDDENSELECTION_NUMBER_R1 22 // right_num_1,
 #define HIDDENSELECTION_NUMBER_R2 23 // right_num_2,
 #define HIDDENSELECTION_FUELPROBE 24 // Fuel_Probe,
-#define HIDDENSELECTION_MLASS 25 // MLASS,
-#define HIDDENSELECTION_LASS 26 // LASS,
-#define HIDDENSELECTION_FULL60M 27 // Full60M,
-#define HIDDENSELECTION_EM_GOARND 28 // emmisive_goarnd,
-#define HIDDENSELECTION_EM_HOVER 29 // emmisive_hvr,
-#define HIDDENSELECTION_EM_FMS 30 // emmisive_fms,
-#define HIDDENSELECTION_EM_CPLD 31 // emmisive_cpld,
-#define HIDDENSELECTION_EM_VS 32 // emmisive_vs
+#define HIDDENSELECTION_MLASS 25 // hs_mlass_co,
+#define HIDDENSELECTION_LASS 26 // hs_lass_co,
+#define HIDDENSELECTION_FULL60M 27 // hs_full60m_co,
+#define HIDDENSELECTION_ESSS 28 // hs_esss,
+#define HIDDENSELECTION_EM_GOARND 29 // emmisive_goarnd,
+#define HIDDENSELECTION_EM_HOVER 30 // emmisive_hvr,
+#define HIDDENSELECTION_EM_FMS 31 // emmisive_fms,
+#define HIDDENSELECTION_EM_CPLD 32 // emmisive_cpld,
+#define HIDDENSELECTION_EM_VS 33 // emmisive_vs
 
 #define HIDDENSELECTIONS "emmisive_overhead", \
           "emmisive_frontDash", \


### PR DESCRIPTION
## Summary
The HIDDENSELECTIONS array gained `hs_esss` at index 28, shifting the five emissive selections to 29-33, but the `HIDDENSELECTION_EM_*` defines still said 28-32 and `hs_esss` had no define at all. This adds `HIDDENSELECTION_ESSS 28`, shifts the five EM defines up by one, and aligns the MLASS/LASS/FULL60M comments with the actual selection names.

Audited before fixing: no code uses any of these defines yet, and the emissive panels are driven by selection name (`setObjectTextureGlobal`), so no use site carried a baked-in compensation - purely corrective for future index-based users.

## Testing
Full `scons all` build of all 25 PBOs succeeded; in-game spot check (2026-08-17) of UH-60M / Slick / HH60 exteriors, liveries, and cockpit emissives all normal; RPT clean.