### PR TITLE
Fix FLIR weapon page pylon references for missing and 4-pylon stations

### DIFF
--- a/addons/MH60M/config/cfgVehicles.hpp
+++ b/addons/MH60M/config/cfgVehicles.hpp
@@ -29,6 +29,10 @@ class VTX_MFD_1_ARMED;
 class VTX_MFD_2_ARMED;
 class VTX_MFD_3_ARMED;
 class VTX_MFD_4_ARMED;
+class VTX_MFD_1_ARMED4;
+class VTX_MFD_2_ARMED4;
+class VTX_MFD_3_ARMED4;
+class VTX_MFD_4_ARMED4;
 class ANVISHUD;
 class ANVISHUD_COPILOT;
 class VTX_CLOCK;
@@ -325,19 +329,22 @@ class CfgVehicles {
         selectionFireAnim = "zasleh_12";
         class VehicleTransport {};
         class MFD: MFD {
-            class VTX_MFD_1 :           VTX_MFD_1_ARMED {};
+            // ARMED4 variants define FLIR_PYLONS_4: the MLASS is the only
+            // craft with 4 pylon stations, so only it may reference
+            // pylonSelected3/4 in MFD conditions
+            class VTX_MFD_1 :           VTX_MFD_1_ARMED4 {};
             class VTX_MFD_1_CMWS :      VTX_MFD_1_CMWS {};
             class VTX_MFD_1_Monospace : VTX_MFD_1_Monospace {};
             class VTX_MFD_1_Bold :      VTX_MFD_1_Bold {};
-            class VTX_MFD_2 :           VTX_MFD_2_ARMED {};
+            class VTX_MFD_2 :           VTX_MFD_2_ARMED4 {};
             class VTX_MFD_2_CMWS :      VTX_MFD_2_CMWS {};
             class VTX_MFD_2_Monospace : VTX_MFD_2_Monospace {};
             class VTX_MFD_2_Bold :      VTX_MFD_2_Bold {};
-            class VTX_MFD_3 :           VTX_MFD_3_ARMED {};
+            class VTX_MFD_3 :           VTX_MFD_3_ARMED4 {};
             class VTX_MFD_3_CMWS :      VTX_MFD_3_CMWS {};
             class VTX_MFD_3_Monospace : VTX_MFD_3_Monospace {};
             class VTX_MFD_3_Bold :      VTX_MFD_3_Bold {};
-            class VTX_MFD_4 :           VTX_MFD_4_ARMED {};
+            class VTX_MFD_4 :           VTX_MFD_4_ARMED4 {};
             class VTX_MFD_4_CMWS :      VTX_MFD_4_CMWS {};
             class VTX_MFD_4_Monospace : VTX_MFD_4_Monospace {};
             class VTX_MFD_4_Bold :      VTX_MFD_4_Bold {};

--- a/addons/uh60_mfd/config/MFD/pages/flir/weapons.hpp
+++ b/addons/uh60_mfd/config/MFD/pages/flir/weapons.hpp
@@ -35,13 +35,15 @@ class pylonsBackground {
 				{{0.55, 0.86}, 1}
 			};
 		}; // lines
-		class Pylon48
+		class Pylon3
 		{
+			// outboard left station; invalid pylon indexes draw nothing, so this
+			// is safe on 2-station craft (previous value 48 never rendered at all)
 			type = "pylonicon";
 			pos[] = {{0.33,0.87},1};
-			pylon = 48;
+			pylon = 3;
 			name = "VTX_H60";
-		}; // Pylon1
+		}; // Pylon3
 		class Pylon1
 		{
 			type = "pylonicon";
@@ -56,13 +58,14 @@ class pylonsBackground {
 			pylon = 2;
 			name = "VTX_H60";
 		}; // Pylon2
-		class Pylon49
+		class Pylon4
 		{
+			// outboard right station (previous value 49 never rendered)
 			type = "pylonicon";
 			pos[] = {{0.67,0.87},1};
-			pylon = 49;
+			pylon = 4;
 			name = "VTX_H60";
-		}; // Pylon1
+		}; // Pylon4
 		TEXT_MID_SCALED(LSR,0.5,0.62+0.07,"LSR",0.05)
 
 		TEXT_MID_SCALED(GUNS,0.5,0.69+0.07,"GUNS",0.05)
@@ -73,8 +76,17 @@ class pylonsBackground {
 	};
 	class red {
 		color[] = common_red;
+		// the engine defines pylonSelectedN only for stations the aircraft has;
+		// referencing missing ones errors in the MFD evaluator on every spawn.
+		// Default build assumes 2 stations; 4-station craft (MLASS) use the
+		// VTX_MFD_*_ARMED4 classes, which define FLIR_PYLONS_4 before this
+		// include - mirroring the FMS_PYLONS_* family pattern.
 		class gun {
-			condition = "(1 -(pylonSelected1 - pylonSelected2 - pylonSelected3 - pylonSelected4)) * mgun";
+#ifdef FLIR_PYLONS_4
+			condition = "(1 - pylonSelected1 - pylonSelected2 - pylonSelected3 - pylonSelected4) * mgun";
+#else
+			condition = "(1 - pylonSelected1 - pylonSelected2) * mgun";
+#endif
 			class poly {
 				type = "polygon";
 				points[] = {
@@ -87,7 +99,11 @@ class pylonsBackground {
 			};
 		};
 		class laser {
+#ifdef FLIR_PYLONS_4
 			condition = "1 - pylonSelected1 - pylonSelected2 - pylonSelected3 - pylonSelected4 - mgun";
+#else
+			condition = "1 - pylonSelected1 - pylonSelected2 - mgun";
+#endif
 			class poly {
 				type = "polygon";
 				points[] = {
@@ -125,6 +141,7 @@ class pylonsBackground {
 				};
 			};
 		}; // sta2
+#ifdef FLIR_PYLONS_4
 		class sta3L {
 			condition = "pylonSelected3";
 			class poly {
@@ -150,7 +167,8 @@ class pylonsBackground {
 					}
 				};
 			};
-		}; // sta3L
+		}; // sta4R
+#endif
 	};
 };
 

--- a/addons/uh60_mfd/config/cfgVehicles.hpp
+++ b/addons/uh60_mfd/config/cfgVehicles.hpp
@@ -295,6 +295,12 @@ class VTX_MFD_1_ARMED: VTX_MFD_1
 {
     #include "MFD\MFD.hpp"
 }; // MFD_1
+#define FLIR_PYLONS_4
+class VTX_MFD_1_ARMED4: VTX_MFD_1
+{
+    #include "MFD\MFD.hpp"
+}; // MFD_1_ARMED4
+#undef FLIR_PYLONS_4
 #undef HAS_ATTACK_PAGE
 class VTX_MFD_1_CMWS
 {
@@ -329,6 +335,12 @@ class VTX_MFD_2_ARMED: VTX_MFD_2
 {
     #include "MFD\MFD.hpp"
 }; // MFD_1
+#define FLIR_PYLONS_4
+class VTX_MFD_2_ARMED4: VTX_MFD_2
+{
+    #include "MFD\MFD.hpp"
+}; // MFD_2_ARMED4
+#undef FLIR_PYLONS_4
 #undef HAS_ATTACK_PAGE
 class VTX_MFD_2_CMWS
 {
@@ -363,6 +375,12 @@ class VTX_MFD_3_ARMED: VTX_MFD_3
 {
     #include "MFD\MFD.hpp"
 }; // MFD_1
+#define FLIR_PYLONS_4
+class VTX_MFD_3_ARMED4: VTX_MFD_3
+{
+    #include "MFD\MFD.hpp"
+}; // MFD_3_ARMED4
+#undef FLIR_PYLONS_4
 #undef HAS_ATTACK_PAGE
 class VTX_MFD_3_CMWS
 {
@@ -397,6 +415,12 @@ class VTX_MFD_4_ARMED: VTX_MFD_4
 {
     #include "MFD\MFD.hpp"
 }; // MFD_1
+#define FLIR_PYLONS_4
+class VTX_MFD_4_ARMED4: VTX_MFD_4
+{
+    #include "MFD\MFD.hpp"
+}; // MFD_4_ARMED4
+#undef FLIR_PYLONS_4
 #undef HAS_ATTACK_PAGE
 class VTX_MFD_4_CMWS
 {


### PR DESCRIPTION
## Summary
The engine only defines `pylonSelectedN` MFD variables for pylon stations the aircraft actually has; the shared FLIR weapon-status page referenced `pylonSelected3/4` unconditionally, so every spawn of every variant dumped undefined-variable bursts into the RPT (24 + 8 lines per session, reproducible in every session). Only the MH60M DAP MLASS actually has 4 stations.

This mirrors the existing `FMS_PYLONS_*` pattern on the FLIR page:
- `flir/weapons.hpp` is parameterized on `FLIR_PYLONS_4`; the default build references only `pylonSelected1/2`, the 4-pylon build keeps the sta3/sta4 carets and full 4-station gun/laser conditions
- new `VTX_MFD_[1-4]_ARMED4` element classes compile the 4-pylon page; `vtx_MH60M_DAP_MLASS` MFDs switch from ARMED to ARMED4, keeping its outboard-station carets fully functional
- fixes a misplaced parenthesis in the gun caret condition that inverted its no-pylon-selected term
- corrects the outboard pylonicon indexes from 48/49 (exist on no aircraft, never rendered) to 3/4 - the MLASS outboard stations now show weapon/ammo icons for the first time; invalid indexes draw nothing, so 2-station craft are unaffected

## Testing
Verified in-game (2026-08-17) on a 2-station variant (carets track gun/sta1/sta2/laser correctly) and on the MLASS (carets follow all four stations, LSR caret no longer shows during outboard selection, outboard weapon icons render, FMS pages unchanged). RPT contains zero pylonselected lines and zero script errors - first fully clean log since tracking began.