### PR TITLE
Remove fold-time debug chat printed to players on every fold

### DIFF
--- a/addons/uh60_misc/functions/fnc_fold.sqf
+++ b/addons/uh60_misc/functions/fnc_fold.sqf
@@ -71,8 +71,6 @@ private _foldTime = switch (_phase) do {
   };
   default { 15 }
 };
-systemChat str _foldTime;
-
 private _fnc_onFinish = {
     (_this select 0) params ["_unit", "_heli"];
 


### PR DESCRIPTION
From the 2026-08-23 legacy audit (improvement plan addendum, Phase 0 tail): `fnc_fold.sqf` systemChat'd the computed fold duration to the player on every fold/unfold. Debug leftover, removed.

Validated in-game 2026-08-23: fold/unfold behave identically with no chat output.