### PR TITLE
Fix config typos with runtime effect

### DIFF
--- a/addons/UH60/cfgSetting.hpp
+++ b/addons/UH60/cfgSetting.hpp
@@ -2,7 +2,7 @@ class CfgSettings {
     class CBA {
         class Versioning {
             class UH60 {
-                main_addon = "UH60";
+                main_addon = "vtx_uh60"; // must name the CfgPatches class - "UH60" matched nothing, so the CBA version check never ran
                 class Dependencies {
                     CBA[] = {"cba_main", {3,18,0}, "(true)"};
                     ACE[] = {"ace_main", {3,18,0}, "(true)"};

--- a/addons/UH60/config/cfgVehicles.hpp
+++ b/addons/UH60/config/cfgVehicles.hpp
@@ -292,8 +292,8 @@ class CfgVehicles {
         class TransportWeapons{};
         radarType = 4;
 
-        weapons[]={CMFlareLauncher};
-        magazines[]={60Rnd_CMFlareMagazine};
+        weapons[]={"CMFlareLauncher"};
+        magazines[]={"60Rnd_CMFlareMagazine"};
 
         class Damage
         {


### PR DESCRIPTION
From the 2026-08-23 legacy audit (improvement plan addendum, Phase 0 tail). Deliberately landed before Phase 1 so its config-dump diff stays pure:

- Quote the flare weapon/magazine classnames in `vtx_H60_base` — the unquoted tokens happened to parse, but every sibling array quotes them and rapify/HEMTT won't be as forgiving.
- `CfgSettings` CBA versioning declared `main_addon = "UH60"`, which is not a CfgPatches class (it's `vtx_uh60`), so the CBA/ACE minimum-version check silently never ran.

Validated in-game 2026-08-23: flares unchanged, clean RPT, and the CBA versioning line now lists `uh60=0.7.7.4` for the first time — the check is live.