### PR TITLE
Fix the rescue hoist for crew members and multiplayer

### DIFF
--- a/addons/uh60_hoist/Armakeybinds.hpp
+++ b/addons/uh60_hoist/Armakeybinds.hpp
@@ -35,16 +35,16 @@ class CfgUserActions
 	class Vtx_HOOK_LOWER {
 		displayName = "Cable Extend (Analog)";
 		tooltip = "Progressively lowers the hook";
-		onActivate = "vtx_uh60_cable_Extending = true; [vehicle player] spawn vtx_uh60_hoist_fnc_lowerHook;";		// _this is always true.
-		onDeactivate = "vtx_uh60_cable_Extending = false";		// _this is always false.
+		onActivate = "[vehicle player, true] call vtx_uh60_hoist_fnc_lowerHook;";		// _this is always true.
+		onDeactivate = "[vehicle player, false] call vtx_uh60_hoist_fnc_lowerHook;";		// _this is always false.
 		onAnalog = "";	// _this is the scalar analog value.
 		analogChangeThreshold = 0.1; // Minimum change required to trigger the onAnalog EH (default: 0.01).
 	};
 	class Vtx_HOOK_RAISE {
 		displayName = "Cable Retract (Analog)";
 		tooltip = "Progressively raises the hook";
-		onActivate = "vtx_uh60_cable_Retracting = true; [vehicle player] spawn vtx_uh60_hoist_fnc_raiseHook;";		// _this is always true.
-		onDeactivate = "vtx_uh60_cable_Retracting = false";		// _this is always false.
+		onActivate = "[vehicle player, true] call vtx_uh60_hoist_fnc_raiseHook;";		// _this is always true.
+		onDeactivate = "[vehicle player, false] call vtx_uh60_hoist_fnc_raiseHook;";		// _this is always false.
 		onAnalog = "";	// _this is the scalar analog value.
 		analogChangeThreshold = 0.1; // Minimum change required to trigger the onAnalog EH (default: 0.01).
 	};

--- a/addons/uh60_hoist/functions/fnc_attachHook.sqf
+++ b/addons/uh60_hoist/functions/fnc_attachHook.sqf
@@ -107,7 +107,14 @@ _unit setVariable [QGVAR(pfhID), [{
   private _distance = ((ropeEndPosition _rope) # 0) distance ((ropeEndPosition _rope) # 1);
   private _isRopeStretched = (_distance > _length + 1.5);
 
-  if (_isRopeStretched) then {
+  // Ride condition: a taut rope (ground snatch-pickup - retracting stretches
+  // it), OR the winch paying out slack while the hook hangs clear of the
+  // ground (cabin deploy - the rope can never go taut, which left attached
+  // riders pinned at the cabin door while the cable reeled out)
+  private _isLoweringOut = !_canStand
+    && {_heli getVariable ["vtx_uh60_hoist_extending", false]}
+    && {_length > _distance};
+  if (_isRopeStretched || _isLoweringOut) then {
     if (!_isUnitInHook) then {
       detach _helper;
       _hook lockCargo [1, false];

--- a/addons/uh60_hoist/functions/fnc_lowerHook.sqf
+++ b/addons/uh60_hoist/functions/fnc_lowerHook.sqf
@@ -1,18 +1,33 @@
 #include "script_component.hpp"
 
-params ["_heli"];
-if !(local _heli) exitWith {[_heli] remoteExecCall ["vtx_uh60_hoist_fnc_lowerHook", _heli]};       
+params ["_heli", ["_active", true]];
 
-private _heli = vehicle player;
-if !([player] call vtx_uh60_hoist_fnc_canControlHoist) exitWith {};
+// permission is checked on the initiating client; the hoist owner may be a
+// dedicated server where player is objNull
+if (_active && {!([player] call vtx_uh60_hoist_fnc_canControlHoist)}) exitWith {};
 
-while {vtx_uh60_cable_Extending} do { 
- private _hoist_vars = _heli getVariable ["vtx_uh60_hoist_vars", []]; 
- _hoist_vars params ["_rope", "_dummy", "_hook"]; 
- private _ropeLength = ropeLength _rope; 
- ropeUnwind [ 
-   _rope, 
-   [MAX_HOIST_SPEED, NEAR_END_SPEED] select (MAX_ROPE_LENGTH - _ropeLength < NEAR_END_THRESHOLD), // slow speed near cable extreme 
-   (_ropeLength + 0.1) min MAX_ROPE_LENGTH 
-  ]; 
+if !(local _heli) exitWith {[_heli, _active] remoteExecCall ["vtx_uh60_hoist_fnc_lowerHook", _heli]};
+
+// key-held state lives on the vehicle so it exists wherever the loop runs
+_heli setVariable ["vtx_uh60_hoist_extending", _active];
+if !(_active) exitWith {};
+if (_heli getVariable ["vtx_uh60_hoist_lowerLoopRunning", false]) exitWith {};
+_heli setVariable ["vtx_uh60_hoist_lowerLoopRunning", true];
+
+[_heli] spawn {
+    params ["_heli"];
+    while {_heli getVariable ["vtx_uh60_hoist_extending", false]} do {
+        private _hoist_vars = _heli getVariable ["vtx_uh60_hoist_vars", []];
+        if (_hoist_vars isEqualTo []) exitWith {};
+        _hoist_vars params ["_rope", "_dummy", "_hook"];
+        private _ropeLength = ropeLength _rope;
+        private _speed = [MAX_HOIST_SPEED, NEAR_END_SPEED] select (MAX_ROPE_LENGTH - _ropeLength < NEAR_END_THRESHOLD); // slow speed near cable extreme
+        ropeUnwind [
+            _rope,
+            _speed,
+            (_ropeLength + _speed * 0.3) min MAX_ROPE_LENGTH // keep the target ahead of the winch so _speed governs
+        ];
+        sleep 0.1;
+    };
+    _heli setVariable ["vtx_uh60_hoist_lowerLoopRunning", false];
 };

--- a/addons/uh60_hoist/functions/fnc_lowerHook.sqf
+++ b/addons/uh60_hoist/functions/fnc_lowerHook.sqf
@@ -9,7 +9,7 @@ if (_active && {!([player] call vtx_uh60_hoist_fnc_canControlHoist)}) exitWith {
 if !(local _heli) exitWith {[_heli, _active] remoteExecCall ["vtx_uh60_hoist_fnc_lowerHook", _heli]};
 
 // key-held state lives on the vehicle so it exists wherever the loop runs
-_heli setVariable ["vtx_uh60_hoist_extending", _active];
+_heli setVariable ["vtx_uh60_hoist_extending", _active, true]; // public: the rider-side attach PFH reads it
 if !(_active) exitWith {};
 if (_heli getVariable ["vtx_uh60_hoist_lowerLoopRunning", false]) exitWith {};
 _heli setVariable ["vtx_uh60_hoist_lowerLoopRunning", true];
@@ -27,6 +27,7 @@ _heli setVariable ["vtx_uh60_hoist_lowerLoopRunning", true];
             _speed,
             (_ropeLength + _speed * 0.3) min MAX_ROPE_LENGTH // keep the target ahead of the winch so _speed governs
         ];
+        _dummy awake true; // the 10 Hz winch cadence lets the rope-end body fall asleep in PhysX
         sleep 0.1;
     };
     _heli setVariable ["vtx_uh60_hoist_lowerLoopRunning", false];

--- a/addons/uh60_hoist/functions/fnc_raiseHook.sqf
+++ b/addons/uh60_hoist/functions/fnc_raiseHook.sqf
@@ -9,7 +9,7 @@ if (_active && {!([player] call vtx_uh60_hoist_fnc_canControlHoist)}) exitWith {
 if !(local _heli) exitWith {[_heli, _active] remoteExecCall ["vtx_uh60_hoist_fnc_raiseHook", _heli]};
 
 // key-held state lives on the vehicle so it exists wherever the loop runs
-_heli setVariable ["vtx_uh60_hoist_retracting", _active];
+_heli setVariable ["vtx_uh60_hoist_retracting", _active, true]; // public: the rider-side attach PFH reads it
 if !(_active) exitWith {};
 if (_heli getVariable ["vtx_uh60_hoist_raiseLoopRunning", false]) exitWith {};
 _heli setVariable ["vtx_uh60_hoist_raiseLoopRunning", true];
@@ -27,6 +27,7 @@ _heli setVariable ["vtx_uh60_hoist_raiseLoopRunning", true];
             _speed,
             (_ropeLength - _speed * 0.3) max 0 // keep the target ahead of the winch so _speed governs
         ];
+        _dummy awake true; // the 10 Hz winch cadence lets the rope-end body fall asleep in PhysX
         sleep 0.1;
     };
     _heli setVariable ["vtx_uh60_hoist_raiseLoopRunning", false];

--- a/addons/uh60_hoist/functions/fnc_raiseHook.sqf
+++ b/addons/uh60_hoist/functions/fnc_raiseHook.sqf
@@ -1,18 +1,33 @@
 #include "script_component.hpp"
 
-params ["_heli"];
-if !(local _heli) exitWith {[_heli] remoteExecCall ["vtx_uh60_hoist_fnc_lowerHook", _heli]};       
+params ["_heli", ["_active", true]];
 
-private _heli = vehicle player;
-if !([player] call vtx_uh60_hoist_fnc_canControlHoist) exitWith {};
+// permission is checked on the initiating client; the hoist owner may be a
+// dedicated server where player is objNull
+if (_active && {!([player] call vtx_uh60_hoist_fnc_canControlHoist)}) exitWith {};
 
-while {vtx_uh60_cable_Retracting} do { 
- private _hoist_vars = _heli getVariable ["vtx_uh60_hoist_vars", []]; 
- _hoist_vars params ["_rope", "_dummy", "_hook"]; 
- private _ropeLength = ropeLength _rope; 
- ropeUnwind [ 
-   _rope, 
-   [MAX_HOIST_SPEED, NEAR_END_SPEED] select (MAX_ROPE_LENGTH - _ropeLength < NEAR_END_THRESHOLD), // slow speed near cable extreme 
-   (_ropeLength - 0.1) min MAX_ROPE_LENGTH 
-  ]; 
+if !(local _heli) exitWith {[_heli, _active] remoteExecCall ["vtx_uh60_hoist_fnc_raiseHook", _heli]};
+
+// key-held state lives on the vehicle so it exists wherever the loop runs
+_heli setVariable ["vtx_uh60_hoist_retracting", _active];
+if !(_active) exitWith {};
+if (_heli getVariable ["vtx_uh60_hoist_raiseLoopRunning", false]) exitWith {};
+_heli setVariable ["vtx_uh60_hoist_raiseLoopRunning", true];
+
+[_heli] spawn {
+    params ["_heli"];
+    while {_heli getVariable ["vtx_uh60_hoist_retracting", false]} do {
+        private _hoist_vars = _heli getVariable ["vtx_uh60_hoist_vars", []];
+        if (_hoist_vars isEqualTo []) exitWith {};
+        _hoist_vars params ["_rope", "_dummy", "_hook"];
+        private _ropeLength = ropeLength _rope;
+        private _speed = [MAX_HOIST_SPEED, NEAR_END_SPEED] select (_ropeLength < NEAR_END_THRESHOLD); // slow speed near cable extreme
+        ropeUnwind [
+            _rope,
+            _speed,
+            (_ropeLength - _speed * 0.3) max 0 // keep the target ahead of the winch so _speed governs
+        ];
+        sleep 0.1;
+    };
+    _heli setVariable ["vtx_uh60_hoist_raiseLoopRunning", false];
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Let any crew member allowed to operate the hoist raise and lower the cable, not just the pilot
- Make the hoist work correctly on dedicated servers
- Make lowering actually take the hook and the person riding it down with the cable, instead of leaving them stuck at the cabin door

Confirmed working by our testers in multiplayer.