### PR TITLE
Fix Engines when multiple helicopters are present

### DIFF
--- a/addons/uh60_engine/functions/fnc_perSecond.sqf
+++ b/addons/uh60_engine/functions/fnc_perSecond.sqf
@@ -8,9 +8,10 @@
 #include "defines.hpp"
 params ["_vehicle"];
 
-private _fuelConsumed = vtx_uh60_engine_lastFuelLevel - fuel _vehicle;
+private _fuel = fuel _vehicle;
+private _fuelConsumed = (_vehicle getVariable ["vtx_uh60_engine_lastFuelLevel", _fuel]) - _fuel;
 
-vtx_uh60_engine_lastFuelLevel = fuel _vehicle;
+_vehicle setVariable ["vtx_uh60_engine_lastFuelLevel", _fuel];
 if (_fuelConsumed > 0) then {
     private _fuelTimeSecondsTotal = (fuel _vehicle) / _fuelConsumed;
     private _fuelTimeStr = [_fuelTimeSecondsTotal] call CBA_fnc_formatElapsedTime;

--- a/addons/uh60_engine/functions/fnc_setup.sqf
+++ b/addons/uh60_engine/functions/fnc_setup.sqf
@@ -9,12 +9,15 @@
 params ["_vehicle"];
 if (!vtx_uh60m_enabled_engine) exitWith {false};
 
-vtx_uh60_engine_engineEH = _vehicle addEventHandler ["engine", vtx_uh60_engine_fnc_engineEH];
-vtx_uh60_engine_lastFuelLevel = fuel _vehicle;
-vtx_uh60_engine_lastAltitude = ((getPosASL _vehicle) # 2);
+// per-vehicle state lives on the vehicle: mission globals would be clobbered
+// by a second H-60 running this module
+if (isNil {_vehicle getVariable "vtx_uh60_engine_engineEH"}) then {
+    _vehicle setVariable ["vtx_uh60_engine_engineEH", _vehicle addEventHandler ["engine", vtx_uh60_engine_fnc_engineEH]];
+};
+_vehicle setVariable ["vtx_uh60_engine_lastFuelLevel", fuel _vehicle];
 #define SET_GLOBAL_DEFAULT(VAR,DEFAULT) _vehicle setVariable [VAR, _vehicle getVariable [VAR, DEFAULT], true];
 SET_GLOBAL_DEFAULT("ENG1_PWR", 0)
-SET_GLOBAL_DEFAULT("ENG1_PWR", 0)
+SET_GLOBAL_DEFAULT("ENG2_PWR", 0)
 SET_GLOBAL_DEFAULT("ENG_START1", false)
 SET_GLOBAL_DEFAULT("ENG_START2", false)
 SET_GLOBAL_DEFAULT("BATT1_ENABLED", false)
@@ -34,13 +37,17 @@ if ((_vehicle animationPhase "handle_wheelbrake") == 1) then {
     [_vehicle, true, "OFF"] call vtx_uh60_engine_fnc_wheelBrakes;
 };
 //Monitor parking brake value
-player addEventHandler ["SelectedRotorLibActionPerformed", {
-    params ["_caller", "_target", "_enumNumber", "_actionId"];
-    if    (!local _caller || !local _target) exitWith {};
-    private _desiredState = if (_enumNumber == 4) then [{1},{0}];
-    _target animateSource ["Handle_wheelbrake", _desiredState, true];
-    [_target, (_enumNumber == 4)] call vtx_uh60_engine_fnc_wheelBrakes;
-}];
+//one player-level handler serves every H-60; add it once or module restarts
+//stack duplicates that never get removed
+if (isNil "vtx_uh60_engine_brakeEH") then {
+    vtx_uh60_engine_brakeEH = player addEventHandler ["SelectedRotorLibActionPerformed", {
+        params ["_caller", "_target", "_enumNumber", "_actionId"];
+        if    (!local _caller || !local _target) exitWith {};
+        private _desiredState = if (_enumNumber == 4) then [{1},{0}];
+        _target animateSource ["Handle_wheelbrake", _desiredState, true];
+        [_target, (_enumNumber == 4)] call vtx_uh60_engine_fnc_wheelBrakes;
+    }];
+};
 
 //New aircraft module
 //--Master ignition key (mik)

--- a/addons/uh60_engine/functions/fnc_shutdown.sqf
+++ b/addons/uh60_engine/functions/fnc_shutdown.sqf
@@ -1,3 +1,7 @@
 params ["_vehicle"];
 
-_vehicle removeEventHandler ["engine", vtx_uh60_engine_engineEH];
+private _ehId = _vehicle getVariable "vtx_uh60_engine_engineEH";
+if (!isNil "_ehId") then {
+    _vehicle removeEventHandler ["engine", _ehId];
+    _vehicle setVariable ["vtx_uh60_engine_engineEH", nil];
+};


### PR DESCRIPTION
**When merged this pull request will:**
- Stop two or more running H-60s in the same mission from interfering with each other's engine systems
- Make each helicopter track its own engine state, so shutting one down can no longer affect another
- Stop duplicate engine handlers from piling up each time someone boards

Confirmed working by our testers in multiplayer.

**Technical Details**
- ENG1_PWR was initialized twice and ENG2_PWR never; initialize both
- engine EH id and last fuel level moved from mission globals to variables on the vehicle: with two H-60s running the module, the globals clobbered each other and shutdown removed the wrong handler
- engine EH registration and removal are now guarded/idempotent, so a repeated module start cannot stack duplicate handlers
- the parking-brake player EH is registered once behind a stored-id guard instead of leaking a duplicate on every module start
- deleted the write-only vtx_uh60_engine_lastAltitude assignment (nothing reads it)