### PR TITLE
remoteExec Whitelist Sound Fixes

### DIFF
--- a/addons/H60_SFX/functions/fn_PlayEngineGlobal.sqf
+++ b/addons/H60_SFX/functions/fn_PlayEngineGlobal.sqf
@@ -3,9 +3,9 @@
  *
  * engine power Sound
  *
- * params (array)[(object) vehicle, (array) _Vars]
+ * params (array)[(object) vehicle, (array) _Vars, (number) _rotorspeed]
  */
-params ["_vehicle","_Vars"];
+params ["_vehicle","_Vars","_rotorspeed"];
 
 //-Engine Start
 if ((_Vars find "STARTING" > -1) && (_rotorspeed < 0.6)) then {

--- a/addons/uh60_engine/XEH_preInit.sqf
+++ b/addons/uh60_engine/XEH_preInit.sqf
@@ -5,4 +5,16 @@ ADDON = false;
 #include "initSettings.sqf";
 #include "XEH_PREP.hpp"
 
+// The H60_SFX sound functions used to be remoteExecCall'd by name, which a
+// mission-defined CfgRemoteExec whitelist blocks. CBA events need no
+// whitelist; the isDedicated guard preserves the old [0,-2] targeting
+["vtx_uh60_engine_playEngineSound", {
+    if (isDedicated) exitWith {};
+    _this call vtx_uh60_Sound_fnc_PlayEngineGlobal;
+}] call CBA_fnc_addEventHandler;
+["vtx_uh60_engine_playAPUSound", {
+    if (isDedicated) exitWith {};
+    _this call vtx_uh60_Sound_fnc_PlayAPUGlobal;
+}] call CBA_fnc_addEventHandler;
+
 ADDON = true;

--- a/addons/uh60_engine/functions/fnc_apuState.sqf
+++ b/addons/uh60_engine/functions/fnc_apuState.sqf
@@ -39,8 +39,11 @@ private _Vars = ["battBusState","apuPwrSwitchState","apuFuelSwitchState"] apply 
 
 //- Play Sound Globally
 [
+  "vtx_uh60_engine_playAPUSound",
   [
-    _vehicle ,_Vars,({_x == "ON"} count _Vars) == 3
-  ],
-  {["battBusState","apuPwrSwitchState","apuFuelSwitchState"] apply {_vehicle getVariable ("vtx_uh60_acft_" + _x)}}
-] remoteExecCall ['vtx_uh60_Sound_fnc_PlayAPUGlobal', [0, -2] select isDedicated];
+    [
+      _vehicle ,_Vars,({_x == "ON"} count _Vars) == 3
+    ],
+    {["battBusState","apuPwrSwitchState","apuFuelSwitchState"] apply {_vehicle getVariable ("vtx_uh60_acft_" + _x)}}
+  ]
+] call CBA_fnc_globalEvent;

--- a/addons/uh60_engine/functions/fnc_engineEH.sqf
+++ b/addons/uh60_engine/functions/fnc_engineEH.sqf
@@ -21,11 +21,13 @@ if(_turnedOn) then {
 
 private _rotorspeed = _vehicle getSoundController "RotorSpeed";
 
-//- Play Sound Globally
+//- Play Sound Globally (rotorspeed must travel with the event - it was a
+//- sender-local variable the receivers never had, so the start/shutdown
+//- sound conditions errored on every remote client)
 [
-  _vehicle,
-  [_eng1State,_eng2State]
-] remoteExecCall ['vtx_uh60_Sound_fnc_PlayEngineGlobal', [0, -2] select isDedicated];
+  "vtx_uh60_engine_playEngineSound",
+  [_vehicle, [_eng1State,_eng2State], _rotorspeed]
+] call CBA_fnc_globalEvent;
 
 /////////////////////////////////
 if (!local _vehicle) exitWith {};


### PR DESCRIPTION
**When merged this pull request will:**
- Make engine sounds work on servers with remoteExec whitelists
- Deliver the engine start/shutdown sounds through the same CBA messaging the rest of the mod uses, instead of the older method that strict servers silently block
- Fix engine start and shutdown sounds never playing for anyone except the person flying (a small error in how the sound was triggered on other players' machines - likely why there were few reports, since rotor noise covers it)

Confirmed working by our testers in multiplayer: everyone nearby now hears engine start and shutdown.