### PR TITLE
add: Laser designator hold key

### DIFF
--- a/addons/uh60_weapons/XEH_PREP.hpp
+++ b/addons/uh60_weapons/XEH_PREP.hpp
@@ -19,6 +19,7 @@ PREP(ehNextWeapon);
 PREP(keyFireSelected);
 PREP(keyNextWeapon);
 PREP(keyMasterArm);
+PREP(keyLaserDesignator);
 PREP(irLaserPFH);
 PREP(onIRLaserOn);
 PREP(keyIRLaser);

--- a/addons/uh60_weapons/XEH_PREP.hpp
+++ b/addons/uh60_weapons/XEH_PREP.hpp
@@ -20,7 +20,7 @@ PREP(keyFireSelected);
 PREP(keyNextWeapon);
 PREP(keyMasterArm);
 PREP(irLaserPFH);
-PREP(onLaserOn);
+PREP(onIRLaserOn);
 PREP(keyIRLaser);
 PREP(assignPylon);
 PREP(assignPylonLocal);

--- a/addons/uh60_weapons/XEH_postInit.sqf
+++ b/addons/uh60_weapons/XEH_postInit.sqf
@@ -4,7 +4,7 @@ if (hasInterface) then {
   #include "ACE_Actions.sqf"
 
   GVAR(irLaserPFH) = -1;
-  [QGVAR(irLaser), LINKFUNC(onLaserOn)] call CBA_fnc_addEventHandler;
+  [QGVAR(irLaser), LINKFUNC(onIRLaserOn)] call CBA_fnc_addEventHandler;
   // Examples
   // ["vtx_uh60_weapons_irLaser", [cameraOn, [0,0,0], 0]] call CBA_fnc_globalEvent;
   // ["vtx_uh60_weapons_irLaser", [cameraOn, "pos", "dir"]] call CBA_fnc_globalEvent;

--- a/addons/uh60_weapons/config/armaKeybinds.hpp
+++ b/addons/uh60_weapons/config/armaKeybinds.hpp
@@ -46,6 +46,12 @@ class CfgUserActions
     tooltip = "Hit this button to toggle the IZLID IR laser.";
     onActivate = "[] call vtx_uh60_weapons_fnc_keyIRLaser;";
   };
+  class vtx_weapons_irLaserHold : vtx_weapons_fireLaser {
+    displayName = "IZLID [HOLD]";
+    tooltip = "Hold this button to activate the IZLID IR laser, release to deactivate.";
+    onActivate = "[1] call vtx_uh60_weapons_fnc_keyIRLaser;";		// _this is always true.
+    onDeactivate = "[0] call vtx_uh60_weapons_fnc_keyIRLaser;";		// _this is always false.
+  };
 };
 class CfgDefaultKeysPresets {};
 class UserActionGroups
@@ -61,7 +67,8 @@ class UserActionGroups
       "vtx_weapons_fireRocket",
       "vtx_weapons_fireLaser",
       "vtx_weapons_fireMissile",
-      "vtx_weapons_irLaser"
+      "vtx_weapons_irLaser",
+      "vtx_weapons_irLaserHold"
     }; // List of all actions inside this category.
   };
 };

--- a/addons/uh60_weapons/config/armaKeybinds.hpp
+++ b/addons/uh60_weapons/config/armaKeybinds.hpp
@@ -1,12 +1,18 @@
 class CfgUserActions
 {
   class vtx_weapons_fireLaser {
-    displayName = "Fire Laser";
-    tooltip = "Hit this key to fire mentioned weapon.";
-    onActivate = "[hct_vehicle, 'Laserdesignator_pilotCamera', 'Laserdesignator_pilotCamera'] call vtx_uh60_weapons_fnc_fireAndResetWeapon;";		// _this is always true.
+    displayName = "Fire Laser [TOGGLE]";
+    tooltip = "Hit this key to toggle the laser designator on/off.";
+    onActivate = "[] call vtx_uh60_weapons_fnc_keyLaserDesignator;";		// _this is always true.
     onDeactivate = "";		// _this is always false.
     onAnalog = "";	// _this is the scalar analog value.
     analogChangeThreshold = 0.1; // Minimum change required to trigger the onAnalog EH (default: 0.01).
+  };
+  class vtx_weapons_fireLaserHold : vtx_weapons_fireLaser {
+    displayName = "Fire Laser [HOLD]";
+    tooltip = "Hold this key to activate the laser designator, release to deactivate.";
+    onActivate = "[1] call vtx_uh60_weapons_fnc_keyLaserDesignator;";		// _this is always true.
+    onDeactivate = "[0] call vtx_uh60_weapons_fnc_keyLaserDesignator;";		// _this is always false.
   };
   class vtx_weapons_masterArm: vtx_weapons_fireLaser {
     displayName = "Master Arm";
@@ -66,6 +72,7 @@ class UserActionGroups
       "vtx_weapons_fireAPKWS",
       "vtx_weapons_fireRocket",
       "vtx_weapons_fireLaser",
+      "vtx_weapons_fireLaserHold",
       "vtx_weapons_fireMissile",
       "vtx_weapons_irLaser",
       "vtx_weapons_irLaserHold"

--- a/addons/uh60_weapons/functions/fnc_keyIRLaser.sqf
+++ b/addons/uh60_weapons/functions/fnc_keyIRLaser.sqf
@@ -4,16 +4,20 @@
  * Key input IR laser
  *
  * Arguments:
- * None
+ * 0: State <NUMBER> (optional, default -1)
+ *    -1: toggle, 0: force off, 1: force on
  *
  * Return Value:
  * None
  *
  * Example:
  * [] call vtx_uh60_weapons_fnc_keyIRLaser
+ * [1] call vtx_uh60_weapons_fnc_keyIRLaser
  *
  * Public: No
  */
+
+params [["_state", -1]];
 
 if !(
   hct_vehicle isKindOf "vtx_MH60M" ||
@@ -23,16 +27,16 @@ if !(
 
 switch (hct_vehicle unitTurret hct_player) do {
   case [-1]: {
-    ["vtx_uh60_weapons_irLaser", [hct_vehicle, [0.085828,5.45809,-0.308074], 0]] call CBA_fnc_globalEvent;
+    ["vtx_uh60_weapons_irLaser", [hct_vehicle, [0.085828,5.45809,-0.308074], 0, _state]] call CBA_fnc_globalEvent;
   };
   case [0]: {
-    ["vtx_uh60_weapons_irLaser", [hct_vehicle, [-0.0956328,5.45809,-0.308074], 0]] call CBA_fnc_globalEvent;
+    ["vtx_uh60_weapons_irLaser", [hct_vehicle, [-0.0956328,5.45809,-0.308074], 0, _state]] call CBA_fnc_globalEvent;
   };
   case [1]: {
-    ["vtx_uh60_weapons_irLaser", [hct_vehicle, "chamber_1", "muzzle_1"]] call CBA_fnc_globalEvent;
+    ["vtx_uh60_weapons_irLaser", [hct_vehicle, "chamber_1", "muzzle_1", _state]] call CBA_fnc_globalEvent;
   };
   case [2]: {
-    ["vtx_uh60_weapons_irLaser", [hct_vehicle, "chamber_2", "muzzle_2"]] call CBA_fnc_globalEvent;
+    ["vtx_uh60_weapons_irLaser", [hct_vehicle, "chamber_2", "muzzle_2", _state]] call CBA_fnc_globalEvent;
   };
   default {};
 };

--- a/addons/uh60_weapons/functions/fnc_keyLaserDesignator.sqf
+++ b/addons/uh60_weapons/functions/fnc_keyLaserDesignator.sqf
@@ -1,0 +1,32 @@
+#include "..\script_component.hpp"
+/*
+ * Author: Perk
+ * Handle the Fire Laser (designator) key, toggle or hold.
+ *
+ * Arguments:
+ * 0: State <NUMBER> (optional, default -1)
+ *    -1: toggle, 0: force off, 1: force on
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call vtx_uh60_weapons_fnc_keyLaserDesignator
+ * [1] call vtx_uh60_weapons_fnc_keyLaserDesignator
+ */
+
+params [["_state", -1]];
+
+IS_EITHER_PILOT;
+IS_MASTER_ARM;
+
+private _isOn = hct_vehicle getVariable ["vtx_uh60_weapons_laserDesignatorOn", false];
+private _turnOn = if (_state == -1) then { !_isOn } else { _state == 1 };
+
+if (_turnOn isEqualTo _isOn) exitWith {};
+
+private _currentWeapon = currentWeapon hct_vehicle;
+driver hct_vehicle forceWeaponFire ["Laserdesignator_pilotCamera", "Laserdesignator_pilotCamera"];
+hct_vehicle selectWeapon _currentWeapon;
+
+hct_vehicle setVariable ["vtx_uh60_weapons_laserDesignatorOn", _turnOn];

--- a/addons/uh60_weapons/functions/fnc_keyLaserDesignator.sqf
+++ b/addons/uh60_weapons/functions/fnc_keyLaserDesignator.sqf
@@ -20,7 +20,7 @@ params [["_state", -1]];
 IS_EITHER_PILOT;
 IS_MASTER_ARM;
 
-private _isOn = hct_vehicle getVariable ["vtx_uh60_weapons_laserDesignatorOn", false];
+private _isOn = isLaserOn hct_vehicle;
 private _turnOn = if (_state == -1) then { !_isOn } else { _state == 1 };
 
 if (_turnOn isEqualTo _isOn) exitWith {};
@@ -33,5 +33,3 @@ driver hct_vehicle forceWeaponFire ["Laserdesignator_pilotCamera", "Laserdesigna
   if (isNull _vehicle) exitWith {};
   _vehicle selectWeapon _weapon;
 }, [hct_vehicle, _currentWeapon]] call CBA_fnc_execNextFrame;
-
-hct_vehicle setVariable ["vtx_uh60_weapons_laserDesignatorOn", _turnOn];

--- a/addons/uh60_weapons/functions/fnc_keyLaserDesignator.sqf
+++ b/addons/uh60_weapons/functions/fnc_keyLaserDesignator.sqf
@@ -27,6 +27,11 @@ if (_turnOn isEqualTo _isOn) exitWith {};
 
 private _currentWeapon = currentWeapon hct_vehicle;
 driver hct_vehicle forceWeaponFire ["Laserdesignator_pilotCamera", "Laserdesignator_pilotCamera"];
-hct_vehicle selectWeapon _currentWeapon;
+
+[{
+  params ["_vehicle", "_weapon"];
+  if (isNull _vehicle) exitWith {};
+  _vehicle selectWeapon _weapon;
+}, [hct_vehicle, _currentWeapon]] call CBA_fnc_execNextFrame;
 
 hct_vehicle setVariable ["vtx_uh60_weapons_laserDesignatorOn", _turnOn];

--- a/addons/uh60_weapons/functions/fnc_onIRLaserOn.sqf
+++ b/addons/uh60_weapons/functions/fnc_onIRLaserOn.sqf
@@ -1,7 +1,7 @@
 #include "..\script_component.hpp"
 /*
  * Author: Ampersand
- * IR Laser on event
+ * IR/IZLID Laser on event
  *
  * Arguments:
  * 0: Vehicle <OBJECT>
@@ -14,7 +14,7 @@
  * None
  *
  * Example:
- * [] call vtx_uh60_weapons_fnc_onLaserOn
+ * [] call vtx_uh60_weapons_fnc_onIRLaserOn
  *
  * Public: No
  */

--- a/addons/uh60_weapons/functions/fnc_onLaserOn.sqf
+++ b/addons/uh60_weapons/functions/fnc_onLaserOn.sqf
@@ -7,6 +7,8 @@
  * 0: Vehicle <OBJECT>
  * 1: Laser Start <ARRAY or STRING>
  * 2: Laser Direction <ARRAY or STRING or 0>
+ * 3: State <NUMBER> (optional, default -1)
+ *    -1: toggle, 0: force off, 1: force on
  *
  * Return Value:
  * None
@@ -17,11 +19,18 @@
  * Public: No
  */
 
-if (_this in GVAR(laserEmitters)) exitWith {
-  GVAR(laserEmitters) = GVAR(laserEmitters) - [_this];
-};
+params ["_vehicle", "_begSel", "_endSel", ["_state", -1]];
+private _emitter = [_vehicle, _begSel, _endSel];
+private _isOn = _emitter in GVAR(laserEmitters);
+private _turnOn = if (_state == -1) then { !_isOn } else { _state == 1 };
 
-GVAR(laserEmitters) pushBackUnique _this;
+if (_turnOn isEqualTo _isOn) exitWith {};
+
+if (_turnOn) then {
+  GVAR(laserEmitters) pushBackUnique _emitter;
+} else {
+  GVAR(laserEmitters) = GVAR(laserEmitters) - [_emitter];
+};
 
 if (
   GVAR(irLaserPFH) != -1


### PR DESCRIPTION
Expands the existing Fire Laser keybind, gives the player the option between toggle or hold firing of the Laser Designator.

[had to resubmit, I messed up my fork a tad bit]