### PR TITLE
Add the devbuild testing pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
     - Main
+    - devbuild
   pull_request:
 
 jobs:

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -1,0 +1,128 @@
+
+# Regenerates the devbuild branch: Main + every open PR labeled ready-for-testing.
+#
+# The branch is machine-generated output - nobody commits to it and it is never
+# merged back. It is rebuilt from scratch on every trigger, so its contents are
+# always exactly derivable from the label list. PRs that fail to merge are
+# skipped, with a comment left on the PR. DEVBUILD.md at the branch root records
+# what each rebuild actually contains.
+#
+# Setup this workflow needs (one-time):
+#   - a "ready-for-testing" label in the repo
+#   - a DEVBUILD_PUSH_TOKEN repo secret: a fine-grained PAT with contents
+#     read/write on this repo. Pushes made with the default workflow token do
+#     not trigger other workflows, so without it the devbuild branch still
+#     regenerates but Validate & Build will not run on it.
+#   - no branch protection rule matching "devbuild" (it gets force-pushed)
+
+name: Devbuild
+
+on:
+  pull_request_target:
+    types: [labeled, unlabeled, synchronize, reopened, closed]
+  push:
+    branches:
+      - Main
+  release:
+    types: [published]
+  workflow_dispatch:
+
+concurrency:
+  group: devbuild-regenerate
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  LABEL: ready-for-testing
+  BASE: Main
+
+jobs:
+  regenerate:
+    runs-on: ubuntu-latest
+    # PR events only matter when the ready-for-testing label is involved:
+    # the label being added/removed, or any update to a PR that carries it.
+    if: >-
+      github.event_name != 'pull_request_target'
+      || github.event.label.name == 'ready-for-testing'
+      || contains(github.event.pull_request.labels.*.name, 'ready-for-testing')
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@v4.2.0
+        with:
+          ref: Main
+          fetch-depth: 0
+          token: ${{ secrets.DEVBUILD_PUSH_TOKEN || github.token }}
+
+      - name: Regenerate devbuild
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git config user.name "devbuild bot"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          base_sha=$(git rev-parse --short HEAD)
+          included=""
+          skipped=""
+
+          # Oldest PR first, so merge order is stable between rebuilds.
+          prs=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --label "$LABEL" \
+                  --json number,title,headRefOid \
+                  --jq 'sort_by(.number) | .[] | [(.number|tostring), .headRefOid, .title] | @tsv')
+
+          while IFS=$'\t' read -r num sha title; do
+            [ -z "${num:-}" ] && continue
+            title=${title//|/-}
+            git fetch -q origin "pull/$num/head"
+            if git merge -q --no-ff --no-edit -m "devbuild: merge #$num" FETCH_HEAD; then
+              echo "merged #$num - $title"
+              included="$included| #$num | $title |"$'\n'
+            else
+              git merge --abort
+              echo "SKIPPED #$num - $title (does not merge cleanly)"
+              skipped="$skipped| #$num | $title |"$'\n'
+              # One comment per PR head commit: the marker makes rebuilds quiet.
+              marker="<!-- devbuild-skipped #$num $sha -->"
+              if ! gh api "repos/$GITHUB_REPOSITORY/issues/$num/comments" --paginate \
+                     --jq '.[].body' | grep -qF "$marker"; then
+                gh pr comment "$num" --repo "$GITHUB_REPOSITORY" --body "$marker
+          This PR is labeled \`$LABEL\` but was **skipped from the devbuild branch**: it does not merge cleanly onto \`$BASE\` together with the other labeled PRs. Rebase it on \`$BASE\` (or resolve the clash with the other labeled PRs) and it will be picked up on the next rebuild."
+              fi
+            fi
+          done <<< "$prs"
+
+          {
+            echo "# devbuild"
+            echo
+            echo "Machine-generated branch: \`$BASE\` @ $base_sha plus every open PR labeled \`$LABEL\`."
+            echo "Do not commit to it, review it, or merge it anywhere - it is rebuilt from scratch on every label change."
+            echo
+            if [ -n "$included" ]; then
+              echo "## In this build"
+              echo
+              echo "| PR | Title |"
+              echo "|---|---|"
+              printf '%s' "$included"
+              echo
+            else
+              echo "No PRs are currently labeled - this build is \`$BASE\` as-is."
+              echo
+            fi
+            if [ -n "$skipped" ]; then
+              echo "## Skipped (labeled, but does not merge cleanly)"
+              echo
+              echo "| PR | Title |"
+              echo "|---|---|"
+              printf '%s' "$skipped"
+              echo
+            fi
+            echo "_Rebuilt $(date -u +'%Y-%m-%d %H:%M UTC') by [this run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)._"
+          } > DEVBUILD.md
+
+          git add DEVBUILD.md
+          git commit -q -m "devbuild: regenerate from $BASE @ $base_sha"
+          git push -q --force origin HEAD:devbuild
+          echo "devbuild regenerated from $BASE @ $base_sha"

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -1,5 +1,5 @@
 
-# Regenerates the devbuild branch: Main + every open PR labeled ready-for-testing.
+# Regenerates the devbuild branch: Main + every open PR labeled "Ready for Testing".
 #
 # The branch is machine-generated output - nobody commits to it and it is never
 # merged back. It is rebuilt from scratch on every trigger, so its contents are
@@ -8,7 +8,7 @@
 # what each rebuild actually contains.
 #
 # Setup this workflow needs (one-time):
-#   - a "ready-for-testing" label in the repo
+#   - a "Ready for Testing" label in the repo
 #   - a DEVBUILD_PUSH_TOKEN repo secret: a fine-grained PAT with contents
 #     read/write on this repo. Pushes made with the default workflow token do
 #     not trigger other workflows, so without it the devbuild branch still
@@ -36,18 +36,18 @@ permissions:
   pull-requests: write
 
 env:
-  LABEL: ready-for-testing
+  LABEL: Ready for Testing
   BASE: Main
 
 jobs:
   regenerate:
     runs-on: ubuntu-latest
-    # PR events only matter when the ready-for-testing label is involved:
+    # PR events only matter when the "Ready for Testing" label is involved:
     # the label being added/removed, or any update to a PR that carries it.
     if: >-
       github.event_name != 'pull_request_target'
-      || github.event.label.name == 'ready-for-testing'
-      || contains(github.event.pull_request.labels.*.name, 'ready-for-testing')
+      || github.event.label.name == 'Ready for Testing'
+      || contains(github.event.pull_request.labels.*.name, 'Ready for Testing')
     steps:
       - name: Checkout base branch
         uses: actions/checkout@v4.2.0

--- a/tools/push_dev.py
+++ b/tools/push_dev.py
@@ -49,7 +49,7 @@ PBO_PREFIX = "hct_h60_"
 MOD_ROOT_FILES = ["meta.cpp", "logo_vtx_ca.paa", "logo_vtx_small_ca.paa"]
 VERSION_FILE = "addons/main/script_version.hpp"
 CHANGELOG = "CHANGELOG-DEV.md"
-TESTING_LABEL = "ready-for-testing"  # the devbuild branch = Main + PRs wearing this label
+TESTING_LABEL = "Ready for Testing"  # the devbuild branch = Main + PRs wearing this label
 DEV_MOD_CPP = """name = "H-60 pack - Development branch";
 picture = "logo_vtx_ca.paa";
 actionName = "Guide";
@@ -189,7 +189,7 @@ def gh(*args):
 
 
 def prs_note(ref, version):
-    """Change note for a devbuild push: the open PRs labeled ready-for-testing.
+    """Change note for a devbuild push: the open PRs labeled Ready for Testing.
 
     That label list is exactly what the devbuild branch is generated from, so
     the Workshop note tells testers precisely which PRs they are testing and

--- a/tools/push_dev.py
+++ b/tools/push_dev.py
@@ -49,6 +49,7 @@ PBO_PREFIX = "hct_h60_"
 MOD_ROOT_FILES = ["meta.cpp", "logo_vtx_ca.paa", "logo_vtx_small_ca.paa"]
 VERSION_FILE = "addons/main/script_version.hpp"
 CHANGELOG = "CHANGELOG-DEV.md"
+TESTING_LABEL = "ready-for-testing"  # the devbuild branch = Main + PRs wearing this label
 DEV_MOD_CPP = """name = "H-60 pack - Development branch";
 picture = "logo_vtx_ca.paa";
 actionName = "Guide";
@@ -179,14 +180,49 @@ def add_build_code(note, ref, sha):
     return note.replace(f"[i]{ref}[/i]", f"[i]{ref} @ {sha}[/i]", 1)
 
 
-def stamp_version(version):
-    """On the checked-out branch: write the version, retitle the Unreleased block, commit both."""
-    label = fmt_version(version)
+def gh(*args):
+    exe = shutil.which("gh") or r"C:\Program Files\GitHub CLI\gh.exe"
+    r = run([exe, *args])
+    if r.returncode != 0:
+        die(f"gh {' '.join(args)} failed:\n{r.stderr.strip()}")
+    return r.stdout
+
+
+def prs_note(ref, version):
+    """Change note for a devbuild push: the open PRs labeled ready-for-testing.
+
+    That label list is exactly what the devbuild branch is generated from, so
+    the Workshop note tells testers precisely which PRs they are testing and
+    where to report findings."""
+    import json
+    prs = json.loads(gh("pr", "list", "--state", "open", "--label", TESTING_LABEL,
+                        "--json", "number,title"))
+    if not prs:
+        die(f"no open PRs carry the '{TESTING_LABEL}' label - nothing to list in the note")
+    label = fmt_version(version) if version else fmt_version(parse_version(show_file(ref, VERSION_FILE)))
+    out = [
+        f"[h1]Dev build {label}[/h1]",
+        f"[i]{ref}[/i]",
+        "This test build contains the following changes under test - please report findings on the matching PR:",
+        "[list]",
+        *[f"[*]{linkify('#' + str(p['number']))} - {p['title']}" for p in sorted(prs, key=lambda p: p["number"])],
+        "[/list]",
+    ]
+    return "\n".join(out)
+
+
+def write_version_file(version):
     hpp = REPO / VERSION_FILE
     hpp_text = hpp.read_text(encoding="utf-8")
     nl = "\r\n" if "\r\n" in hpp_text else "\n"
     hpp.write_text(nl.join([f"#define MAJOR {version[0]}", f"#define MINOR {version[1]}",
                             f"#define PATCHLVL {version[2]}", f"#define BUILD {version[3]}", ""]), encoding="utf-8")
+
+
+def stamp_version(version):
+    """On the checked-out branch: write the version, retitle the Unreleased block, commit both."""
+    label = fmt_version(version)
+    write_version_file(version)
 
     cl = REPO / CHANGELOG
     text = cl.read_text(encoding="utf-8")
@@ -263,9 +299,14 @@ def main():
     note.add_argument("--note-file", help="file containing the change note")
     note.add_argument("--note-from-changelog", action="store_true",
                       help="build the note from the top version block of CHANGELOG-DEV.md at <ref>")
+    note.add_argument("--note-from-prs", action="store_true",
+                      help=f"build the note from the open PRs labeled '{TESTING_LABEL}' (for devbuild pushes)")
     ver = ap.add_mutually_exclusive_group()
     ver.add_argument("--bump", action="store_true", help="increment the build digit of the version on <ref> and stamp it")
     ver.add_argument("--version", help="stamp this exact version (e.g. 0.7.9.1) - use for the first push of a cycle")
+    ap.add_argument("--no-commit", action="store_true",
+                    help="stamp the version into the build only, committing nothing - required for pushing the "
+                         "regenerated devbuild branch, where commits would be wiped on the next rebuild")
     ap.add_argument("--preview-note", action="store_true", help="print the change note and exit (no build, no upload)")
     ap.add_argument("--dry-run", action="store_true", help="build and verify, skip the upload")
     ap.add_argument("--yes", action="store_true", help="skip the confirmation prompt")
@@ -276,9 +317,14 @@ def main():
     version, stamp = target_version(args.branch, args)
     if stamp and args.skip_build:
         die("--bump/--version need a checkout to stamp the branch; drop --skip-build")
+    if args.no_commit and not args.version:
+        die("--no-commit needs an explicit --version: nothing is committed, so --bump would "
+            "have no stamped base to count from")
 
     if args.note_from_changelog:
         note_text = changelog_note(args.branch, version if stamp else None)
+    elif args.note_from_prs:
+        note_text = prs_note(args.branch, version if stamp else None)
     elif args.note is not None:
         note_text = args.note
     else:
@@ -301,11 +347,17 @@ def main():
         git("checkout", "-q", args.branch)
         try:
             if stamp:
-                stamp_version(version)
+                if args.no_commit:
+                    write_version_file(version)
+                    print(f"  stamped {fmt_version(version)} into {VERSION_FILE} (build-time only, nothing committed)")
+                else:
+                    stamp_version(version)
             sha = git("rev-parse", "--short", "HEAD")
             wipe_mirror()
             count, total = build()
         finally:
+            if stamp and args.no_commit:
+                git("checkout", "-q", "--", VERSION_FILE)
             git("checkout", "-q", previous)
     else:
         sha = "(skip-build)"


### PR DESCRIPTION
**When merged this pull request will:**
- Automatically maintain a devbuild branch containing Main plus every open PR labeled ready-for-testing, so fixes can be play-tested before review finishes
- Leave a comment on any labeled PR that can't be included because of a conflict
- Keep a DEVBUILD.md file on the branch listing exactly what each rebuild contains
- Build the devbuild branch in CI like any other push
- Workshop push script to list the included PRs in the change note and stamp the version without committing
