### PR TITLE
Queue devbuild rebuilds instead of cancelling them

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,13 @@ on:
     - devbuild
   pull_request:
 
+# When several commits land on the same PR in quick succession, only the
+# latest build matters - cancel the superseded ones. Push builds (Main,
+# devbuild) are never cancelled.
+concurrency:
+  group: validate-build-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # validate:
   #   runs-on: ubuntu-latest
@@ -26,6 +33,12 @@ jobs:
   #   - name: Check for BOM
   #     uses: arma-actions/bom-check@master
   build:
+    # PRs from forks cannot build: the Arma 3 Tools download secret is
+    # withheld from fork-triggered runs, so their build always fails at
+    # setup. Skip instead of showing outside contributors a guaranteed
+    # red X - fork PRs get built via the devbuild branch once labeled
+    # "Ready for Testing".
+    if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
     runs-on: windows-2022
     steps:
       - name: Checkout the source code

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -27,9 +27,13 @@ on:
     types: [published]
   workflow_dispatch:
 
+# Queue runs, never cancel: a merged PR fires push + closed events almost
+# together, and with cancel-in-progress the closed-event run cancels the real
+# push run BEFORE its own job evaluates the label condition and skips - so
+# nothing regenerates. Runs take seconds and are idempotent; queueing is safe.
 concurrency:
   group: devbuild-regenerate
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: write

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -81,11 +81,16 @@ jobs:
             [ -z "${num:-}" ] && continue
             title=${title//|/-}
             git fetch -q origin "pull/$num/head"
-            if git merge -q --no-ff --no-edit -m "devbuild: merge #$num" FETCH_HEAD; then
+            # Squash-merge: each included PR lands as ONE commit, so the
+            # devbuild log mirrors what Main's history will look like when
+            # the PR is properly merged. The PR itself is untouched and
+            # stays open - only Main receiving its commits would close it.
+            if git merge -q --squash FETCH_HEAD; then
+              git commit -q --allow-empty -m "devbuild: #$num - $title"
               echo "merged #$num - $title"
               included="$included| #$num | $title |"$'\n'
             else
-              git merge --abort
+              git reset -q --hard HEAD  # --squash sets no MERGE_HEAD, so 'merge --abort' cannot clean this up
               echo "SKIPPED #$num - $title (does not merge cleanly)"
               skipped="$skipped| #$num | $title |"$'\n'
               # One comment per PR head commit: the marker makes rebuilds quiet.


### PR DESCRIPTION
**When merged this pull request will:**
- Fix devbuild rebuilds sometimes cancelling each other when GitHub fires two events at nearly the same time (like a PR merging). The rebuild that got cancelled is the one that had real work to do; runs now wait in line instead.
- Makes the build more reliable if multiple events get triggered
- Fix devbuild rebuilds sometimes cancelling each other when GitHub fires two events at nearly the same time — rebuilds now wait in line instead
- Put each tested PR into the devbuild branch as one clean commit, matching how it will eventually look on Main
- Stop running the build check on PRs from forks, where it always fails for a technical reason that isn't the contributor's fault — those PRs get built through the devbuild branch instead
- Cancel outdated build runs when a PR gets several pushes in a row
