### PR TITLE
Bug: Cabin Crew positions are able to use autohover keybinds

### DIFF
--- a/addons/uh60_fd/functions/fnc_modeSet.sqf
+++ b/addons/uh60_fd/functions/fnc_modeSet.sqf
@@ -6,7 +6,10 @@
  * params (array)[(object) vehicle]
  */
 
+#include "..\script_component.hpp"
 #include "defines.hpp"
+
+IS_EITHER_PILOT;
 
 params ["_vehicle", "_mode"];
 


### PR DESCRIPTION
Corrects the issue of Door Gunners/Troop Commanders being able to put the aircraft in a auto hover when it is supposed to be restricted to the Pilot/Co-Pilot.

Issue: https://github.com/Project-Hatchet/H-60/issues/557