### PR TITLE
Fix Geolock Indicator not updating

### DIFF
--- a/addons/uh60_flir/functions/fnc_perFrame.sqf
+++ b/addons/uh60_flir/functions/fnc_perFrame.sqf
@@ -56,12 +56,8 @@ if (_bootTime > -1) then {
   };
 };
 
-// Skip the camera/overlay updates only when NO FLIR view is on screen. The
-// pilot's fullscreen is the vanilla GUNNER view (isPipHidden is always true
-// there), so it must count as a fullscreen view alongside the copilot's
-// scripted camera - reuse _inFullScreenCam from above rather than restating it.
-// (The old "Use Scripted Camera" setting picked one of the two; #559 removed
-// the setting but kept only the scripted-camera half - regression fixed here.)
+// isPipHidden is always true outside INTERNAL view, so the pilot's GUNNER
+// fullscreen must count as an on-screen FLIR view here or its updates skip
 if (vtx_uh60_flir_isPipHidden && {!_inFullScreenCam}) exitWith {};
 
 [_vehicle] call vtx_uh60_flir_fnc_updateCamera;

--- a/addons/uh60_flir/functions/fnc_perFrame.sqf
+++ b/addons/uh60_flir/functions/fnc_perFrame.sqf
@@ -56,8 +56,7 @@ if (_bootTime > -1) then {
   };
 };
 
-// isPipHidden is always true outside INTERNAL view, so the pilot's GUNNER
-// fullscreen must count as an on-screen FLIR view here or its updates skip
+// Skip the camera/overlay updates only when NO FLIR view is on screen.
 if (vtx_uh60_flir_isPipHidden && {!_inFullScreenCam}) exitWith {};
 
 [_vehicle] call vtx_uh60_flir_fnc_updateCamera;

--- a/addons/uh60_flir/functions/fnc_perFrame.sqf
+++ b/addons/uh60_flir/functions/fnc_perFrame.sqf
@@ -56,9 +56,13 @@ if (_bootTime > -1) then {
   };
 };
 
-// (Use Scripted Camera setting removed - its off-mode selected the copilot
-// turret optics, disabled until the model gains a View - Gunner LOD, #560)
-if (vtx_uh60_flir_isPipHidden && {!vtx_uh60_flir_isInScriptedCamera}) exitWith {};
+// Skip the camera/overlay updates only when NO FLIR view is on screen. The
+// pilot's fullscreen is the vanilla GUNNER view (isPipHidden is always true
+// there), so it must count as a fullscreen view alongside the copilot's
+// scripted camera - reuse _inFullScreenCam from above rather than restating it.
+// (The old "Use Scripted Camera" setting picked one of the two; #559 removed
+// the setting but kept only the scripted-camera half - regression fixed here.)
+if (vtx_uh60_flir_isPipHidden && {!_inFullScreenCam}) exitWith {};
 
 [_vehicle] call vtx_uh60_flir_fnc_updateCamera;
 _this call vtx_uh60_flir_fnc_updateUIValues;


### PR DESCRIPTION
**When merged this pull request will:**
- Fix the pilot's fullscreen FLIR view not refreshing its overlay readouts (like the GEOLOCK indicator) and not keeping the picture-in-picture camera aligned while in fullscreen. A change in #559 accidentally stopped treating the pilot's fullscreen as a FLIR view, so the per-frame updates were skipped there.
