### PR TITLE
Adjust deadzone for FLIR slewing input

### DIFF
--- a/addons/uh60_flir/functions/fnc_handleSlew.sqf
+++ b/addons/uh60_flir/functions/fnc_handleSlew.sqf
@@ -45,7 +45,7 @@ vtx_uh60_flir_isSlewing = _keySlew || {vtx_uh60_flir_isInScriptedCamera && {_mou
 
 // Deliberate FLIR movement: key slew always counts; mouse only above a small
 // deadzone so an accidental mouselook twitch cannot demote a vehicle follow
-private _hasSlewInput = vtx_uh60_flir_isSlewing && {_keySlew || {(abs _inputX + abs _inputY) > 5}}; // 5 Is when you can notice some sort of deadzoning.
+private _hasSlewInput = vtx_uh60_flir_isSlewing && {_keySlew || {(abs _inputX + abs _inputY) > vtx_uh60_flir_setting_SlewDeadzone}};
 
 // Tracking state machine (per design spec):
 //   FREE    - camera moves freely

--- a/addons/uh60_flir/functions/fnc_handleSlew.sqf
+++ b/addons/uh60_flir/functions/fnc_handleSlew.sqf
@@ -45,7 +45,7 @@ vtx_uh60_flir_isSlewing = _keySlew || {vtx_uh60_flir_isInScriptedCamera && {_mou
 
 // Deliberate FLIR movement: key slew always counts; mouse only above a small
 // deadzone so an accidental mouselook twitch cannot demote a vehicle follow
-private _hasSlewInput = vtx_uh60_flir_isSlewing && {_keySlew || {(abs _inputX + abs _inputY) > 0.005}};
+private _hasSlewInput = vtx_uh60_flir_isSlewing && {_keySlew || {(abs _inputX + abs _inputY) > 5}}; // 5 Is when you can notice some sort of deadzoning.
 
 // Tracking state machine (per design spec):
 //   FREE    - camera moves freely

--- a/addons/uh60_flir/initSettings.sqf
+++ b/addons/uh60_flir/initSettings.sqf
@@ -64,3 +64,12 @@
     [0.01, 100, 1, 2], // data for this setting: [min, max, default, number of shown trailing decimals]
     nil // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
 ] call CBA_fnc_addSetting;
+
+[
+    "vtx_uh60_flir_setting_SlewDeadzone", // Internal setting name, should always contain a tag! This will be the global variable which takes the value of the setting.
+    "SLIDER", // setting type
+    [LSTRING(SlewDeadzone), LSTRING(SlewDeadzone_Tooltip)], // Pretty name shown inside the ingame settings menu. Can be stringtable entry.
+    ["UH-60M", "FLIR"], // Pretty name of the category where the setting can be found. Can be stringtable entry.
+    [0, 20, 5, 2], // data for this setting: [min, max, default, number of shown trailing decimals]
+    nil // "_isGlobal" flag. Set this to true to always have this setting synchronized between all clients in multiplayer
+] call CBA_fnc_addSetting;

--- a/addons/uh60_flir/stringtable.xml
+++ b/addons/uh60_flir/stringtable.xml
@@ -37,6 +37,12 @@
         <Key ID="STR_VTX_UH60_FLIR_KeyXFactor_Tooltip">
             <English>Sensitivity multiplier for pan vs tilt. Use this to adjust diagonal movement.</English>
         </Key>
+        <Key ID="STR_VTX_UH60_FLIR_SlewDeadzone">
+            <English>FLIR Slew Deadzone</English>
+        </Key>
+        <Key ID="STR_VTX_UH60_FLIR_SlewDeadzone_Tooltip">
+            <English>How much mouse slew input is needed before it counts as deliberate movement, e.g. demoting a vehicle follow to a ground lock.</English>
+        </Key>
         <Key ID="STR_VTX_UH60_FLIR_AnimateTurret">
             <English>Animate Turret</English>
         </Key>


### PR DESCRIPTION
You start to notice GEOLOCK Deadzoning when it is established at 5 rather than 0.005