### PR TITLE
Improve: Synchronise ACRE comms interactions #593

### DIFF
--- a/addons/uh60_acre/CfgEventHandlers.hpp
+++ b/addons/uh60_acre/CfgEventHandlers.hpp
@@ -9,3 +9,9 @@ class Extended_PreInit_EventHandlers {
         init = QUOTE(call COMPILE_FILE(XEH_preInit));
     };
 };
+
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
+    };
+};

--- a/addons/uh60_acre/XEH_PREP.hpp
+++ b/addons/uh60_acre/XEH_PREP.hpp
@@ -6,3 +6,4 @@ PREP(cycleRadioChannel);
 PREP(cycleSpatial);
 PREP(fmsSetPreset);
 PREP(radioStatusUpdate);
+PREP(notifyOtherSeat);

--- a/addons/uh60_acre/XEH_postInit.sqf
+++ b/addons/uh60_acre/XEH_postInit.sqf
@@ -1,0 +1,12 @@
+#include "script_component.hpp"
+#include "\z\vtx\addons\uh60_fms\config\fmsDefines.hpp"
+
+[QGVAR(radioUpdated), {
+  params ["_vehicle"];
+  // don't bother refreshing if they're not even on a comm page
+  private _fmsPageIndex = if (player == driver _vehicle) then {FMS_R_PAGE_INDEX} else {FMS_L_PAGE_INDEX};
+  private _currentPage = (getUserMFDValue _vehicle) # _fmsPageIndex;
+  if (_currentPage in [FMS_PAGE_COMM_ACRE, FMS_PAGE_COMM_INFO_ACRE]) then {
+    [_vehicle] call vtx_uh60_fms_fnc_perSecond;
+  };
+}] call CBA_fnc_addEventHandler;

--- a/addons/uh60_acre/functions/fnc_cycleRadioChannel.sqf
+++ b/addons/uh60_acre/functions/fnc_cycleRadioChannel.sqf
@@ -3,14 +3,14 @@
  *
  * handles cycling radio channel
  *
- * 
+ *
  */
 params ["_vehicle","_index","_cycle"];
 
 private _newChannel = nil;
 
 _racks = [_vehicle] call acre_sys_rack_fnc_getVehicleRacks;
-_radio = [_racks # _index] call acre_sys_rack_fnc_getMountedRadio;  
+_radio = [_racks # _index] call acre_sys_rack_fnc_getMountedRadio;
 _oldChannel = [_radio] call acre_api_fnc_getRadioChannel;
 
 if (_cycle == 1) then {
@@ -22,4 +22,5 @@ if (_cycle == 1) then {
 };
 
 [_radio, _newChannel] call acre_api_fnc_setRadioChannel;
+[_vehicle] call vtx_uh60_acre_fnc_notifyOtherSeat;
 true

--- a/addons/uh60_acre/functions/fnc_cycleSpatial.sqf
+++ b/addons/uh60_acre/functions/fnc_cycleSpatial.sqf
@@ -15,20 +15,21 @@ private _radio = [_racks # _index] call acre_sys_rack_fnc_getMountedRadio;
 private _oldSpatial = [_radio] call acre_api_fnc_getRadioSpatial;
 
 if (_cycle == 1) then {
-	switch (_oldSpatial) do 
+	switch (_oldSpatial) do
 	{
 		case "LEFT": {_newSpatial = "RIGHT";};
 		case "RIGHT": {_newSpatial = "CENTER";};
-		case "CENTER": {_newSpatial = "LEFT";}; 
+		case "CENTER": {_newSpatial = "LEFT";};
 	};
 } else {
-	switch (_oldSpatial) do 
+	switch (_oldSpatial) do
 	{
 		case "LEFT": {_newSpatial = "CENTER";};
 		case "RIGHT": {_newSpatial = "LEFT";};
-		case "CENTER": {_newSpatial = "RIGHT";}; 
+		case "CENTER": {_newSpatial = "RIGHT";};
 	};
 };
 
 _setSpatial = [_radio, _newSpatial] call acre_api_fnc_setRadioSpatial;
+[_vehicle] call vtx_uh60_acre_fnc_notifyOtherSeat;
 true

--- a/addons/uh60_acre/functions/fnc_fmsSetPreset.sqf
+++ b/addons/uh60_acre/functions/fnc_fmsSetPreset.sqf
@@ -3,7 +3,7 @@
  *
  * changes radio channel based on selected preset
  *
- * 
+ *
  */
 params ["_vehicle", "_radioIndex", "_presetIndex", ["_pageData", nil]];
 
@@ -15,3 +15,4 @@ _channel = fms_comm_presets_page_index * 4 + _presetIndex;
 _vehicle setUserMFDvalue _pageData;
 
 [_vehicle] call vtx_uh60_fms_fnc_perSecond;
+[_vehicle] call vtx_uh60_acre_fnc_notifyOtherSeat;

--- a/addons/uh60_acre/functions/fnc_notifyOtherSeat.sqf
+++ b/addons/uh60_acre/functions/fnc_notifyOtherSeat.sqf
@@ -1,0 +1,13 @@
+#include "..\script_component.hpp"
+
+params ["_vehicle"];
+
+private _otherUnit = if (player == driver _vehicle) then {
+  _vehicle turretUnit [0]
+} else {
+  driver _vehicle
+};
+
+if (isNull _otherUnit) exitWith {};
+
+[QGVAR(radioUpdated), [_vehicle], _otherUnit] call CBA_fnc_targetEvent;

--- a/addons/uh60_acre/functions/fnc_radioStatusUpdate.sqf
+++ b/addons/uh60_acre/functions/fnc_radioStatusUpdate.sqf
@@ -3,23 +3,24 @@
  *
  * turns radio on/off
  *
- * 
+ *
  */
 
 params ["_vehicle", "_index"];
 
 private _status = _vehicle getVariable [(format ["vtx_uh60_radio_%1", _index]),0];
 
-private _wiredRacks = [_vehicle, acre_player, 0, "wiredRacks"] call acre_sys_intercom_fnc_getStationConfiguration; 
-private _selectedRack = _wiredRacks select (_index); 
-// Set the previous rack to no monitor unless it is selected in the monitor knob 
-      
-if (_status == 0) then {  
+private _wiredRacks = [_vehicle, acre_player, 0, "wiredRacks"] call acre_sys_intercom_fnc_getStationConfiguration;
+private _selectedRack = _wiredRacks select (_index);
+// Set the previous rack to no monitor unless it is selected in the monitor knob
+
+if (_status == 0) then {
 	_selectedRack set [1, 3];
-	_vehicle setVariable [(format ["vtx_uh60_radio_%1", _index]), 1];
+	_vehicle setVariable [(format ["vtx_uh60_radio_%1", _index]), 1, true];
 } else {
 	private _selectedRack = _wiredRacks select (_index);
  	_selectedRack set [1,0];
-		_vehicle setVariable [(format ["vtx_uh60_radio_%1", _index]), 0]; 
-}; 
-[_vehicle] call vtx_uh60_fms_perSecond; 
+		_vehicle setVariable [(format ["vtx_uh60_radio_%1", _index]), 0, true];
+};
+[_vehicle] call vtx_uh60_fms_fnc_perSecond;
+[_vehicle] call vtx_uh60_acre_fnc_notifyOtherSeat;


### PR DESCRIPTION
Radios on/off status was only set locally, so the other seat never saw it change. cycleRadioChannel, cycleSpatial and fmsSetPreset also never told the other seat anything happened, so their FMS just sat stale until they poked something themselves.

Now the on/off variable is broadcasted between the seats, and all four functions fire a targeted event at whichever seat didn't make the change so their FMS redraws right away instead of waiting on the once a second ambient loop. The handler only bothers redrawing if that seat is actually looking at a comm page, so it's not forcing a NAV or fuel page recalc for a radio change. So on this change it's really optimization approach.

Also fixed a typo that was silently killing the local refresh too it was calling vtx_uh60_fms_perSecond instead of vtx_uh60_fms_fnc_perSecond, so even the seat making the change never saw it update without a manual page flip.

https://github.com/Project-Hatchet/H-60/issues/593