### PR TITLE
60 Network Improvements

### DIFF
--- a/addons/uh60_engine/functions/fnc_perSecond.sqf
+++ b/addons/uh60_engine/functions/fnc_perSecond.sqf
@@ -25,15 +25,9 @@ if (_isPilotSeat) then {
     };
 };
 
-private _esisCount = _vehicle getVariable ["ESIS_COUNTER", 0];
-if (!local _vehicle) exitWith {
-    _vehicle setUserMFDValue [49, _esisCount];
-};
-
-if (_esisCount > -1) then {
-    _vehicle setVariable ["ESIS_COUNTER", _esisCount - 1, true];
-    _vehicle setUserMFDValue [49, _esisCount];
-};
+private _esisStartTime = _vehicle getVariable ["ESIS_START_TIME", cba_missionTime];
+private _esisCount = round (70 - (cba_missionTime - _esisStartTime)) max -1;
+_vehicle setUserMFDValue [49, _esisCount];
 
 if (difficultyEnabledRTD) then {
     [_vehicle] call vtx_uh60_engine_fnc_acftRTDController;

--- a/addons/uh60_engine/functions/fnc_perSecond.sqf
+++ b/addons/uh60_engine/functions/fnc_perSecond.sqf
@@ -6,18 +6,23 @@
  * params (array)[(object) vehicle]
  */
 #include "defines.hpp"
+#include "\z\vtx\addons\uh60_fms\config\fmsDefines.hpp"
 params ["_vehicle"];
 
 private _fuel = fuel _vehicle;
 private _fuelConsumed = (_vehicle getVariable ["vtx_uh60_engine_lastFuelLevel", _fuel]) - _fuel;
 
 _vehicle setVariable ["vtx_uh60_engine_lastFuelLevel", _fuel];
-if (_fuelConsumed > 0) then {
-    private _fuelTimeSecondsTotal = (fuel _vehicle) / _fuelConsumed;
-    private _fuelTimeStr = [_fuelTimeSecondsTotal] call CBA_fnc_formatElapsedTime;
-    vtx_uh60_engine_fuelTime = _fuelTimeStr;
-    vtx_uh60_engine_fuelConsumption = _fuelConsumed * 2040 * 60;
-    vtx_uh60_engine_fuelRange = round ((_fuelTimeSecondsTotal * (vectorMagnitude (velocity _vehicle))) * 0.000539957);
+
+private _isPilotSeat = (player == driver _vehicle) || {(_vehicle unitTurret player) isEqualTo [0]};
+if (_isPilotSeat) then {
+    private _fmsPageIndex = if (player == driver _vehicle) then {FMS_R_PAGE_INDEX} else {FMS_L_PAGE_INDEX};
+    if (((getUserMFDValue _vehicle) # _fmsPageIndex) == FMS_PAGE_PERFORMANCE && {_fuelConsumed > 0}) then {
+        private _fuelTimeSecondsTotal = (fuel _vehicle) / _fuelConsumed;
+        SET("vtx_uh60_engine_fuelTime", [_fuelTimeSecondsTotal] call CBA_fnc_formatElapsedTime);
+        SET("vtx_uh60_engine_fuelConsumption", _fuelConsumed * 2040 * 60);
+        SET("vtx_uh60_engine_fuelRange", round ((_fuelTimeSecondsTotal * (vectorMagnitude (velocity _vehicle))) * 0.000539957));
+    };
 };
 
 private _esisCount = _vehicle getVariable ["ESIS_COUNTER", 0];

--- a/addons/uh60_engine/functions/fnc_setup.sqf
+++ b/addons/uh60_engine/functions/fnc_setup.sqf
@@ -25,8 +25,9 @@ SET_GLOBAL_DEFAULT("BATT2_ENABLED", false)
 SET_GLOBAL_DEFAULT("BATT1_POWER", 100)
 SET_GLOBAL_DEFAULT("BATT2_POWER", 100)
 SET_GLOBAL_DEFAULT("POWER_DRAIN_RATE", 0.11)
-SET_GLOBAL_DEFAULT("ESIS_COUNTER", 70)
-_vehicle setUserMFDValue [49, _vehicle getVariable ["ESIS_COUNTER", 70]];
+SET_GLOBAL_DEFAULT("ESIS_START_TIME", cba_missionTime)
+private _esisStartTime = _vehicle getVariable ["ESIS_START_TIME", cba_missionTime];
+_vehicle setUserMFDValue [49, (round (70 - (cba_missionTime - _esisStartTime))) max -1];
 
 _vehicle enableAutoTrimRTD true;
 

--- a/addons/uh60_engine/functions/fnc_setup.sqf
+++ b/addons/uh60_engine/functions/fnc_setup.sqf
@@ -37,6 +37,22 @@ if ((_vehicle animationPhase "handle_wheelbrake") == 1) then {
 } else {
     [_vehicle, true, "OFF"] call vtx_uh60_engine_fnc_wheelBrakes;
 };
+//Re-assert RotorLib brake state whenever this machine gains ownership:
+//fnc_wheelBrakes' setBrakesRTD is one-shot on whoever owned the vehicle at
+//toggle time, so a locality transfer (controls handoff, pilot egress) hands
+//the new owner a RotorLib sim whose brakes disagree with the lever (#498)
+if (isNil {_vehicle getVariable "vtx_uh60_engine_brakeLocalEH"}) then {
+    _vehicle setVariable ["vtx_uh60_engine_brakeLocalEH", _vehicle addEventHandler ["Local", {
+        params ["_vehicle", "_isLocal"];
+        if (_isLocal) then {
+            private _state = if ((_vehicle animationPhase "handle_wheelbrake") > 0.5) then [{1},{0}];
+            _vehicle setBrakesRTD [_state, 3];
+            if (vtx_uh60_ui_showDebugMessages) then {
+                diag_log format ["VTX BRAKES REASSERT (locality gained) | %1 | brake:%2", _vehicle, _state];
+            };
+        };
+    }]];
+};
 //Monitor parking brake value
 //one player-level handler serves every H-60; add it once or module restarts
 //stack duplicates that never get removed

--- a/addons/uh60_fd/functions/fnc_achievePitch.sqf
+++ b/addons/uh60_fd/functions/fnc_achievePitch.sqf
@@ -1,4 +1,7 @@
+	#include "defines.hpp"
+
 	params ["_vehicle", "_frameTime", "_desiredPitch"];
 	(_vehicle call BIS_fnc_getPitchBank) params ["_pitch", "_bank"];
 	private _outputForce = -1 * ([_vehicle, "pitch", _frameTime, _desiredPitch, _pitch] call hct_util_fnc_pidRun);
-	_vehicle addTorque (_vehicle vectorModelToWorld [_outputForce max (-1*ias_max_pitchTorque) min ias_max_pitchTorque,0,0]);
+	private _maxPitchTorque = GET("maxPitchTorque",2000);
+	_vehicle addTorque (_vehicle vectorModelToWorld [_outputForce max (-1*_maxPitchTorque) min _maxPitchTorque,0,0]);

--- a/addons/uh60_fd/functions/fnc_alt.sqf
+++ b/addons/uh60_fd/functions/fnc_alt.sqf
@@ -16,15 +16,15 @@ private _altDiff = _altGoal - _alt;
 private _verticalVelocity = (velocity _vehicle) # 2;
 private _verticalVelocityGoal = (_altDiff max -1 min 1) *0.3048;
 if ((abs _altDiff) > 3) then {
-    if (vtx_uh60_fd_lastAltMatch) then {
-        vtx_uh60_fd_lastAltChangeTime = cba_missionTime;
+    if (GET("lastAltMatch",true)) then {
+        SET("lastAltChangeTime", cba_missionTime);
     };
-    vtx_uh60_fd_lastAltMatch = false;
-    private _timeSinceChange = cba_missionTime - vtx_uh60_fd_lastAltChangeTime;
+    SET("lastAltMatch", false);
+    private _timeSinceChange = cba_missionTime - GET("lastAltChangeTime",cba_missionTime);
     if(vtx_uh60_ui_showDebugMessages) then {systemChat str _timeSinceChange;};
     _verticalVelocityGoal = (_altDiff max -1 min 1) * (if (_timeSinceChange < 5) then [{1.21}, {4.87}]);
 } else {
-    vtx_uh60_fd_lastAltMatch = true;
+    SET("lastAltMatch", true);
 };
 
 [_vehicle, _frameTime, _verticalVelocityGoal] call vtx_uh60_fd_fnc_verticalVelocity;

--- a/addons/uh60_fd/functions/fnc_hdg.sqf
+++ b/addons/uh60_fd/functions/fnc_hdg.sqf
@@ -1,5 +1,7 @@
+#include "defines.hpp"
+
 params ["_vehicle", "_frameTime", ["_fmsCoupled", false]];
-if (vtx_uh60_rotorRPM < 0.04) exitWith {};
+if (GET("rotorRPM",0) < 0.04) exitWith {};
 private _desiredHeading = (round(((vehicle player) animationSourcePhase "FD_5_ROT")*36));
 private _waypointCount = count (waypoints (group player));
 private _hasWaypoint = _waypointCount > (currentWaypoint (group player));
@@ -18,7 +20,8 @@ _reldir = {
 private _headingDiff = [_desiredHeading, _heading] call _reldir;
 private _outputForce = -1 * ([_vehicle, "hdg", _frameTime, 0, _headingDiff] call hct_util_fnc_pidRun);
 // systemChat str ["running HDG", round _desiredHeading, round _heading, _headingDiff, _outputForce];
-_vehicle addTorque (_vehicle vectorModelToWorld [0,0,_outputForce max (-1*ias_max_rudderTorque) min ias_max_rudderTorque]);
+private _maxRudderTorque = GET("maxRudderTorque",800);
+_vehicle addTorque (_vehicle vectorModelToWorld [0,0,_outputForce max (-1*_maxRudderTorque) min _maxRudderTorque]);
 
 private _speedKts = (speed _vehicle) / 1.852;
 private _desiredBank = 0;
@@ -35,4 +38,5 @@ if (abs _headingDiff < 2) then {
 (_vehicle call BIS_fnc_getPitchBank) params ["_pitch", "_bank"];
 private _bankForce = -1 * ([_vehicle, "roll", _frameTime, _desiredBank max -30 min 30, _bank] call hct_util_fnc_pidRun);
 // systemChat str ["banking", _desiredBank, _bankForce, _bank];
-_vehicle addTorque (_vehicle vectorModelToWorld [0,_bankForce max (-1*ias_max_pitchTorque) min ias_max_pitchTorque,0]);
+private _maxPitchTorque = GET("maxPitchTorque",2000);
+_vehicle addTorque (_vehicle vectorModelToWorld [0,_bankForce max (-1*_maxPitchTorque) min _maxPitchTorque,0]);

--- a/addons/uh60_fd/functions/fnc_ias.sqf
+++ b/addons/uh60_fd/functions/fnc_ias.sqf
@@ -1,5 +1,7 @@
+#include "defines.hpp"
+
 params ["_vehicle", "_frameTime"];
-if (vtx_uh60_rotorRPM < 0.04) exitWith {};
+if (GET("rotorRPM",0) < 0.04) exitWith {};
 // systemChat str ["running ias", _frameTime];
 
 private _desiredSpeedKts = (round((_vehicle animationSourcePhase "FD_4_ROT")*10))*10;

--- a/addons/uh60_fd/functions/fnc_perFrame.sqf
+++ b/addons/uh60_fd/functions/fnc_perFrame.sqf
@@ -15,12 +15,12 @@ _vehicle setUserMFDvalue [37, (velocityModelSpace _vehicle) # 0];
 _vehicle setUserMFDvalue [38, (velocityModelSpace _vehicle) # 1];
 
 private _autohoverKeyDetected = (inputAction "autoHover" > 0 || inputAction "autoHoverCancel" > 0);
-if (_autohoverKeyDetected && !vtx_uh60_fd_autoHoverKeyDown) then {
-    vtx_uh60_fd_autoHoverKeyDown = true;
+if (_autohoverKeyDetected && !GET("autoHoverKeyDown",false)) then {
+    SET("autoHoverKeyDown", true);
     [_vehicle, "HVR"] call vtx_uh60_fd_fnc_modeSet;
 };
 if (!_autohoverKeyDetected) then {
-    vtx_uh60_fd_autoHoverKeyDown = false;
+    SET("autoHoverKeyDown", false);
 };
 
 if (!isEngineOn _vehicle) exitWith {};
@@ -30,21 +30,22 @@ if (isAutoHoverOn _vehicle && !(_vehicle getVariable ["hvr", false])) exitWith {
 };
 
 private _rotorState = _vehicle animationPhase "hrotor";
-if (_rotorState > vtx_uh60_lastRotorAnim) then {
-    vtx_uh60_rotorRPM = (_rotorState - vtx_uh60_lastRotorAnim);
+private _lastRotorAnim = GET("lastRotorAnim",_rotorState);
+if (_rotorState > _lastRotorAnim) then {
+    SET("rotorRPM", (_rotorState - _lastRotorAnim));
 };
-vtx_uh60_lastRotorAnim = _rotorState;
+SET("lastRotorAnim", _rotorState);
 
 private _altCode = GET("alt_mode",nil);
 if (!isNil "_altCode") then {_this call _altCode} else {
     if (vtx_uh60m_simpleCollective && difficultyEnabledRTD) then {
         private _collective = (inputAction "HeliCollectiveRaise") - (inputAction "HeliCollectiveLower");
         if (_collective != 0) then {
-            vtx_uh60_fd_collectiveHeld = vtx_uh60_fd_collectiveHeld + _frameTime;
+            SET("collectiveHeld", GET("collectiveHeld",0) + _frameTime);
         } else {
-            vtx_uh60_fd_collectiveHeld = 1;
+            SET("collectiveHeld", 1);
         };
-        [_vehicle, _frameTime, _collective * 8 * ((vtx_uh60_fd_collectiveHeld / 3) min 3)] call vtx_uh60_fd_fnc_verticalVelocity;
+        [_vehicle, _frameTime, _collective * 8 * ((GET("collectiveHeld",0) / 3) min 3)] call vtx_uh60_fd_fnc_verticalVelocity;
     };
 };
 

--- a/addons/uh60_fd/functions/fnc_perFrame.sqf
+++ b/addons/uh60_fd/functions/fnc_perFrame.sqf
@@ -28,6 +28,9 @@ if (!local _vehicle) exitWith {};
 
 private _airborne = !isTouchingGround _vehicle;
 if (GET("wasAirborne",false) && {!_airborne}) then {
+    if (vtx_uh60_ui_showDebugMessages) then {
+        diag_log format ["VTX FD PID RESET (touchdown) | %1", _vehicle];
+    };
     { [_vehicle, _x] call hct_util_fnc_pidReset } forEach
         ["collective", "collectiveSFM", "ias", "pitch", "hdg", "roll", "drift"];
 };

--- a/addons/uh60_fd/functions/fnc_perFrame.sqf
+++ b/addons/uh60_fd/functions/fnc_perFrame.sqf
@@ -25,6 +25,13 @@ if (!_autohoverKeyDetected) then {
 
 if (!isEngineOn _vehicle) exitWith {};
 if (!local _vehicle) exitWith {};
+
+private _airborne = !isTouchingGround _vehicle;
+if (GET("wasAirborne",false) && {!_airborne}) then {
+    { [_vehicle, _x] call hct_util_fnc_pidReset } forEach
+        ["collective", "collectiveSFM", "ias", "pitch", "hdg", "roll", "drift"];
+};
+SET("wasAirborne", _airborne);
 if (isAutoHoverOn _vehicle && !(_vehicle getVariable ["hvr", false])) exitWith {
     player action ["AutoHoverCancel", _vehicle];
 };

--- a/addons/uh60_fd/functions/fnc_perSecond.sqf
+++ b/addons/uh60_fd/functions/fnc_perSecond.sqf
@@ -11,12 +11,12 @@
 params ["_vehicle", "_frameTime"];
 
 private _alt = (getPosASL _vehicle) # 2 - ((getPos _vehicle) # 2);
-vtx_uh60_fd_terrainSlope = _alt - vtx_uh60_fd_lastTerrainAlt;
-vtx_uh60_fd_lastTerrainAlt = _alt;
+SET("terrainSlope", _alt - GET("lastTerrainAlt",_alt));
+SET("lastTerrainAlt", _alt);
 
 if (isEngineOn _vehicle) then {
-	vtx_uh60_poweredTime = vtx_uh60_poweredTime + 1;
+	SET("poweredTime", GET("poweredTime",0) + 1);
 };
 if (!isTouchingGround _vehicle) then {
-	vtx_uh60_flightTime = vtx_uh60_flightTime + 1;
+	SET("flightTime", GET("flightTime",0) + 1);
 };

--- a/addons/uh60_fd/functions/fnc_perSecond.sqf
+++ b/addons/uh60_fd/functions/fnc_perSecond.sqf
@@ -20,3 +20,15 @@ if (isEngineOn _vehicle) then {
 if (!isTouchingGround _vehicle) then {
 	SET("flightTime", GET("flightTime",0) + 1);
 };
+
+if (vtx_uh60_ui_showDebugMessages) then {
+	private _pidDump = ["collective", "collectiveSFM", "ias", "pitch", "hdg", "roll", "drift"] apply {
+		private _pid = _vehicle getVariable [format ["hct_pid_%1", _x], []];
+		format ["%1 e:%2 i:%3", _x, (_pid param [3, 0]) toFixed 4, (_pid param [4, 0]) toFixed 4]
+	};
+	diag_log format [
+		"VTX FD PID | %1 | local:%2 wow:%3 eng:%4 | %5",
+		_vehicle, local _vehicle, isTouchingGround _vehicle, isEngineOn _vehicle,
+		_pidDump joinString " | "
+	];
+};

--- a/addons/uh60_fd/functions/fnc_ralt.sqf
+++ b/addons/uh60_fd/functions/fnc_ralt.sqf
@@ -16,18 +16,18 @@ private _altDiff = _altGoal - _alt;
 private _verticalVelocity = (velocity _vehicle) # 2;
 private _verticalVelocityGoal = (_altDiff max -1 min 1) *0.3048;
 if ((abs _altDiff) > 3) then {
-    if (vtx_uh60_fd_lastAltMatch) then {
-        vtx_uh60_fd_lastAltChangeTime = cba_missionTime;
+    if (GET("lastAltMatch",true)) then {
+        SET("lastAltChangeTime", cba_missionTime);
     };
-    vtx_uh60_fd_lastAltMatch = false;
-    private _timeSinceChange = cba_missionTime - vtx_uh60_fd_lastAltChangeTime;
+    SET("lastAltMatch", false);
+    private _timeSinceChange = cba_missionTime - GET("lastAltChangeTime",cba_missionTime);
     _verticalVelocityGoal = (_altDiff max -1 min 1) * (if (_timeSinceChange < 5) then [{1.21}, {4.87}]);
 } else {
-    vtx_uh60_fd_lastAltMatch = true;
+    SET("lastAltMatch", true);
 };
 
 if (_altGoal > _alt) then {
-    _verticalVelocityGoal = _verticalVelocityGoal max vtx_uh60_fd_terrainSlope;
+    _verticalVelocityGoal = _verticalVelocityGoal max GET("terrainSlope",0);
 };
 
 [_vehicle, _frameTime, _verticalVelocityGoal] call vtx_uh60_fd_fnc_verticalVelocity;

--- a/addons/uh60_fd/functions/fnc_setup.sqf
+++ b/addons/uh60_fd/functions/fnc_setup.sqf
@@ -12,11 +12,11 @@ params ["_vehicle"];
 if (!vtx_uh60m_enabled_fd) exitWith {false};
 
 [_vehicle] call vtx_uh60_fd_fnc_updatePanel;
-vtx_uh60_fd_lastAltMatch = true;
-vtx_uh60_fd_lastAltChangeTime = cba_missionTime;
-vtx_uh60_fd_lastTerrainAlt = ((getPosASL _vehicle) # 2) - ((getPos _vehicle) # 2);
-vtx_uh60_fd_terrainSlope = 0;
-vtx_uh60_fd_collectiveHeld = 0;
+SET("lastAltMatch", true);
+SET("lastAltChangeTime", cba_missionTime);
+SET("lastTerrainAlt", ((getPosASL _vehicle) # 2) - ((getPos _vehicle) # 2));
+SET("terrainSlope", 0);
+SET("collectiveHeld", 0);
 
 [_vehicle, "collective", 0.3, 0.2, 0] call hct_util_fnc_pidCreate;
 [_vehicle, "collectiveSFM", 2000, 20, 0] call hct_util_fnc_pidCreate;
@@ -25,15 +25,15 @@ vtx_uh60_fd_collectiveHeld = 0;
 [_vehicle, "hdg", 30, 0, 0] call hct_util_fnc_pidCreate;
 [_vehicle, "roll", 10, 0, 0] call hct_util_fnc_pidCreate;
 [_vehicle, "drift", 1, 0, 0] call hct_util_fnc_pidCreate;
-vs_max_collectiveForce = 3000;
-ias_max_pitchTorque = 2000;
-ias_max_rudderTorque = 800;
-vtx_uh60_lastRotorAnim = vehicle player animationPhase "hrotor";
-vtx_uh60_rotorRPM = 0;
-vtx_uh60_fd_autoHoverKeyDown = false;
+SET("maxCollectiveForce", 3000);
+SET("maxPitchTorque", 2000);
+SET("maxRudderTorque", 800);
+SET("lastRotorAnim", vehicle player animationPhase "hrotor");
+SET("rotorRPM", 0);
+SET("autoHoverKeyDown", false);
 
-vtx_uh60_flightTime = 0;
-vtx_uh60_poweredTime = 0;
+SET("flightTime", 0);
+SET("poweredTime", 0);
 
 _vehicle setObjectTextureGlobal ["emmisive_cpld", "#(rgb,8,8,3)color(0,1,0,1)"];
 

--- a/addons/uh60_fd/functions/fnc_setup.sqf
+++ b/addons/uh60_fd/functions/fnc_setup.sqf
@@ -25,6 +25,16 @@ SET("collectiveHeld", 0);
 [_vehicle, "hdg", 30, 0, 0] call hct_util_fnc_pidCreate;
 [_vehicle, "roll", 10, 0, 0] call hct_util_fnc_pidCreate;
 [_vehicle, "drift", 1, 0, 0] call hct_util_fnc_pidCreate;
+
+if (isNil {_vehicle getVariable "vtx_uh60_fd_localEH"}) then {
+    _vehicle setVariable ["vtx_uh60_fd_localEH", _vehicle addEventHandler ["Local", {
+        params ["_vehicle", "_isLocal"];
+        if (_isLocal) then {
+            { [_vehicle, _x] call hct_util_fnc_pidReset } forEach
+                ["collective", "collectiveSFM", "ias", "pitch", "hdg", "roll", "drift"];
+        };
+    }]];
+};
 SET("maxCollectiveForce", 3000);
 SET("maxPitchTorque", 2000);
 SET("maxRudderTorque", 800);

--- a/addons/uh60_fd/functions/fnc_setup.sqf
+++ b/addons/uh60_fd/functions/fnc_setup.sqf
@@ -30,6 +30,9 @@ if (isNil {_vehicle getVariable "vtx_uh60_fd_localEH"}) then {
     _vehicle setVariable ["vtx_uh60_fd_localEH", _vehicle addEventHandler ["Local", {
         params ["_vehicle", "_isLocal"];
         if (_isLocal) then {
+            if (vtx_uh60_ui_showDebugMessages) then {
+                diag_log format ["VTX FD PID RESET (locality gained) | %1", _vehicle];
+            };
             { [_vehicle, _x] call hct_util_fnc_pidReset } forEach
                 ["collective", "collectiveSFM", "ias", "pitch", "hdg", "roll", "drift"];
         };

--- a/addons/uh60_fd/functions/fnc_verticalVelocity.sqf
+++ b/addons/uh60_fd/functions/fnc_verticalVelocity.sqf
@@ -6,6 +6,8 @@
  * params (array)[(object) vehicle, (SCALAR) frameTime, (SCALAR) verticalVelocity in MS]
  */
 
+#include "defines.hpp"
+
 params ["_vehicle", "_frameTime", "_verticalVelocityGoal"];
 
 private _verticalVelocity = (velocity _vehicle) # 2;
@@ -14,9 +16,10 @@ if (difficultyEnabledRTD) then {
 	private _output = [_vehicle, "collective", _frameTime, _verticalVelocityGoal, _verticalVelocity] call hct_util_fnc_pidRun;
 	_vehicle setActualCollectiveRTD (_output min 1 max 0);
 } else {
-	if (vtx_uh60_rotorRPM < 0.04) exitWith {};
+	if (GET("rotorRPM",0) < 0.04) exitWith {};
 	private _output = [_vehicle, "collectiveSFM", _frameTime, _verticalVelocityGoal, _verticalVelocity] call hct_util_fnc_pidRun;
-	private _force = (_output max (-1*vs_max_collectiveForce) min vs_max_collectiveForce);
+	private _maxCollectiveForce = GET("maxCollectiveForce",3000);
+	private _force = (_output max (-1*_maxCollectiveForce) min _maxCollectiveForce);
 	// systemchat str [round _verticalVelocityGoal, round _verticalVelocity, round _force, round _output];
 	_vehicle addForce [(_vehicle vectorModelToWorld [0,0,_force]), (getCenterOfMass _vehicle)];
 };

--- a/addons/uh60_flir/functions/fnc_perSecond.sqf
+++ b/addons/uh60_flir/functions/fnc_perSecond.sqf
@@ -26,7 +26,9 @@ if (_vehicle getVariable ["vtx_uh60_flir_stowed", true]) then {
       private _timeRemaining = (_bootTime + 20) - cba_missionTime;
       _vehicle setUserMFDText [10, format["PREPARING PAYLOAD %1", floor _timeRemaining]];
     } else {
-      _vehicle setVariable ["vtx_uh60_flir_stowed", false, true];
+      if (player == driver _vehicle || {isNull (driver _vehicle)}) then {
+        _vehicle setVariable ["vtx_uh60_flir_stowed", false, true];
+      };
       {
         if ((getUserMFDValue _vehicle) # _x > 5 - 0.99 && (getUserMFDValue _vehicle) # _x < 5 + 0.99) exitWith {
           [_vehicle, _x, 5, true] call vtx_uh60_mfd_fnc_switchPage;

--- a/addons/uh60_fms/functions/fnc_perSecond.sqf
+++ b/addons/uh60_fms/functions/fnc_perSecond.sqf
@@ -25,9 +25,9 @@ private _strings = switch ((getUserMFDValue _vehicle) # _fms) do {
             };
         };
         [
-            str ceil (missionNamespace getVariable ["vtx_uh60_engine_fuelConsumption",0]),
-            missionNamespace getVariable ["vtx_uh60_engine_fuelTime","--:--:--"],
-            str floor (missionNamespace getVariable ["vtx_uh60_engine_fuelRange",0]),
+            str ceil (_vehicle getVariable ["vtx_uh60_engine_fuelConsumption",0]),
+            _vehicle getVariable ["vtx_uh60_engine_fuelTime","--:--:--"],
+            str floor (_vehicle getVariable ["vtx_uh60_engine_fuelRange",0]),
             str round (((_weight # 0) + (_weight # 1) + (_weight # 3) + (_weight # 4)) * 2.20462),
             _stateText
         ]

--- a/addons/uh60_weapons/functions/fnc_ehFireSelected.sqf
+++ b/addons/uh60_weapons/functions/fnc_ehFireSelected.sqf
@@ -31,13 +31,16 @@ if !(
   _vehicle fireAtTarget [objNull];
 };
 
+if (!isNil "vtx_uh60_weapons_fireSelectedPFH") exitWith {};
+
 private _reloadTime = getNumber (configFile >> "CfgWeapons" >> _currentWeapon >> "_reloadTime");
-[{
+vtx_uh60_weapons_fireSelectedPFH = [{
     params ["_args", "_pfhID"];
     _args params ["_vehicle", "_currentWeapon", "_endTime"];
 
     if (vtx_uh60_weapons_isKeyUp || {CBA_missionTime >= _endTime}) exitWith {
         [_pfhID] call CBA_fnc_removePerFrameHandler;
+        vtx_uh60_weapons_fireSelectedPFH = nil;
     };
 
     _vehicle fireAtTarget [objNull];

--- a/addons/uh60_weapons/functions/fnc_fired.sqf
+++ b/addons/uh60_weapons/functions/fnc_fired.sqf
@@ -4,11 +4,11 @@ if (vtx_uh60_ui_showDebugMessages) then {systemchat "HELLFIRE LAUNCHED";};
 private _vehicle = vehicle player;
 if (vehicle _gunner == _vehicle) then {
 	addCamShake [3, 1, 25];
-	vtx_uh60_hellfire_lastLaunchTime = cba_missionTime;
-	
+	_vehicle setVariable ["vtx_uh60_hellfire_lastLaunchTime", cba_missionTime, true];
+
 	private _targetPoint = ([_vehicle] call vtx_uh60_weapons_fnc_isLOBL) # 1;
 	if (!(_targetPoint isEqualTo [0,0,0])) then {
-		vtx_uh60_hellfire_currentTof = ceil ((_vehicle distance _targetPoint) / 250);
+		_vehicle setVariable ["vtx_uh60_hellfire_impactTime", cba_missionTime + ceil ((_vehicle distance _targetPoint) / 250), true];
 	};
 };
 if (_ammo == "VTX_Hellfire_AGM114K" || _ammo == "VTX_Hellfire_AGM114N") then {

--- a/addons/uh60_weapons/functions/fnc_perSecond.sqf
+++ b/addons/uh60_weapons/functions/fnc_perSecond.sqf
@@ -1,7 +1,6 @@
 params ["_vehicle"];
 
 [_vehicle] call vtx_uh60_weapons_fnc_updateMFDValues;
-vtx_uh60_hellfire_currentTof = (vtx_uh60_hellfire_currentTof - 1) max -1;
 
 if (ace_player == driver _vehicle) then {
   if (_vehicle getVariable ["vtx_uh60_weapons_masterArm_isSafe", false]) then {

--- a/addons/uh60_weapons/functions/fnc_setup.sqf
+++ b/addons/uh60_weapons/functions/fnc_setup.sqf
@@ -3,8 +3,8 @@ params ["_vehicle"];
 
 _vehicle setVariable ["vtx_uh60_hellfire_laserCodeIndex", _vehicle getVariable ["vtx_uh60_hellfire_laserCodeIndex", 0], true];
 
-vtx_uh60_hellfire_lastLaunchTime = 0;
-vtx_uh60_hellfire_currentTof = -1;
+_vehicle setVariable ["vtx_uh60_hellfire_lastLaunchTime", 0];
+_vehicle setVariable ["vtx_uh60_hellfire_impactTime", -1];
 
 {
   _vehicle setUserMFDValue [_x, 0];

--- a/addons/uh60_weapons/functions/fnc_updateMFDValues.sqf
+++ b/addons/uh60_weapons/functions/fnc_updateMFDValues.sqf
@@ -13,8 +13,10 @@ if (_stabilized) then {
 	private _gridStr = format ["%1    %2    %3    %4", _gridArea select 0, _gridArea select 1, _grid select 0, _grid select 1];
 	_outputString = _outputString + _gridStr;
 };
-if (vtx_uh60_hellfire_currentTof > -1) then {
-	_outputString = _outputString + format["   HF TOF = %1", vtx_uh60_hellfire_currentTof];
+private _impactTime = _vehicle getVariable ["vtx_uh60_hellfire_impactTime", -1];
+private _currentTof = if (_impactTime < 0) then {-1} else {(ceil (_impactTime - cba_missionTime)) max -1};
+if (_currentTof > -1) then {
+	_outputString = _outputString + format["   HF TOF = %1", _currentTof];
 } else { // if no hellfire in the air, do the waypoint check
 	if (_stabilized) then {
 		{
@@ -52,7 +54,7 @@ if (_foundLaser) then {
 	_constraintsBoxType = if (_angleDiff < 7.5) then [{3}, {4}];
 };
 
-if (cba_missionTime < vtx_uh60_hellfire_lastLaunchTime + 1.5) then {
+if (cba_missionTime < (_vehicle getVariable ["vtx_uh60_hellfire_lastLaunchTime", 0]) + 1.5) then {
 	_constraintsBoxType = 6;
 };
 


### PR DESCRIPTION
### Fix Flight Director state leaking between helicopters
- Rotor RPM, collective/pitch/rudder force clamps, alt hold timing, collective held, autohover key state, flight/powered time were all bare mission global's in uh60_fd, not per-vehicle

- A client that never left their original H-60 was fine; one that took over a different aircraft (esp. via an in-place seat swap, which skips the getIn that normally re runs setup) kept whatever rotor phase/terrain alt was left from the last one

- Stale rotor RPM feeding the heading/pitch control loop while WoW kicks in lines up with the spinning/rolling reports after pilot-copilot handoffs

- Moved everything onto the vehicle via the existing GET/SET macros already used.