### PR TITLE
fix mh60m doors appearing on init

### DIFF
--- a/addons/MH60M/config.cpp
+++ b/addons/MH60M/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         units[] = {"vtx_MH60M", "vtx_MH60M_DAP", "vtx_MH60M_DAP_MLASS"};
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
-        requiredAddons[] = {"vtx_UH60_weapons", "vtx_UH60_mfd", "vtx_UH60_fms", "vtx_UH60_anvishud"};
+        requiredAddons[] = {"vtx_UH60_config", "vtx_UH60_weapons", "vtx_UH60_mfd", "vtx_UH60_fms", "vtx_UH60_anvishud"};
         author = "";
         authors[] = {""};
         VERSION_CONFIG;

--- a/addons/MH60M/config/cfgVehicles.hpp
+++ b/addons/MH60M/config/cfgVehicles.hpp
@@ -90,6 +90,8 @@ class CfgVehicles {
             ANIM_INIT(CabinSeats_1_Hide,1);
             ANIM_INIT(CabinSeats_2_Hide,1);
             ANIM_INIT(CabinSeats_3_Hide,1);
+            ANIM_INIT(Door_RF_Hide,1);
+            ANIM_INIT(Door_LF_Hide,1);
             ANIM_INIT(Cockpitdoors_Hide,1);
             ANIM_INIT(Minigun_Sight_L_hide,1);
             ANIM_INIT(Minigun_Sight_R_hide,1);
@@ -201,6 +203,8 @@ class CfgVehicles {
             ANIM_INIT(CabinSeats_1_Hide,1);
             ANIM_INIT(CabinSeats_2_Hide,1);
             ANIM_INIT(CabinSeats_3_Hide,1);
+            ANIM_INIT(Door_RF_Hide,1);
+            ANIM_INIT(Door_LF_Hide,1);
             ANIM_INIT(Cockpitdoors_Hide,1);
             ANIM_INIT(FuelProbe_show,1);
             ANIM_INIT(MITAS_show,1);
@@ -303,6 +307,8 @@ class CfgVehicles {
             ANIM_INIT(CabinSeats_1_Hide,1);
             ANIM_INIT(CabinSeats_2_Hide,1);
             ANIM_INIT(CabinSeats_3_Hide,1);
+            ANIM_INIT(Door_RF_Hide,1);
+            ANIM_INIT(Door_LF_Hide,1);
             ANIM_INIT(Cockpitdoors_Hide,1);
             ANIM_INIT(FuelProbe_show,1);
             ANIM_INIT(MITAS_show,1);


### PR DESCRIPTION
return to intended behaviour of hidden by default
