### PR TITLE
Stamp devbuild versions automatically

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -103,10 +103,36 @@ jobs:
             fi
           done <<< "$prs"
 
+          # Stamp the dev version: Main's version with PATCHLVL+1 (dev builds
+          # always work toward the next release) and a BUILD counter that
+          # increments on every rebuild and resets to 1 when a release bumps
+          # Main's version. The stamp only ever exists on this generated
+          # branch - Main's script_version.hpp is never touched, and each
+          # rebuild re-derives the stamp from Main plus the previous devbuild
+          # tip. push_dev.py picks the version up from the branch, so devbuild
+          # Workshop pushes no longer need --version/--bump.
+          VERSION_FILE=addons/main/script_version.hpp
+          parse_ver() { tr -d '\r' | awk '/#define (MAJOR|MINOR|PATCHLVL|BUILD) /{v[$2]=$3} END{print v["MAJOR"], v["MINOR"], v["PATCHLVL"], v["BUILD"]}'; }
+          read -r main_major main_minor main_patch _ < <(git show "$base_sha:$VERSION_FILE" | parse_ver)
+          dev_patch=$((main_patch + 1))
+          build=1
+          if git fetch -q origin devbuild 2>/dev/null; then
+            read -r p_major p_minor p_patch p_build < <(git show FETCH_HEAD:"$VERSION_FILE" 2>/dev/null | parse_ver)
+            if [ "${p_major:-}" = "$main_major" ] && [ "${p_minor:-}" = "$main_minor" ] && [ "${p_patch:-}" = "$dev_patch" ]; then
+              build=$((p_build + 1))
+            fi
+          fi
+          dev_version="$main_major.$main_minor.$dev_patch.$build"
+          printf '#define MAJOR %s\n#define MINOR %s\n#define PATCHLVL %s\n#define BUILD %s\n' \
+            "$main_major" "$main_minor" "$dev_patch" "$build" > "$VERSION_FILE"
+          git add "$VERSION_FILE"
+          echo "stamped $dev_version"
+
           {
             echo "# devbuild"
             echo
             echo "Machine-generated branch: \`$BASE\` @ $base_sha plus every open PR labeled \`$LABEL\`."
+            echo "In-game version stamp: \`$dev_version\` (stable \`$BASE\` is \`$main_major.$main_minor.$main_patch\`)."
             echo "Do not commit to it, review it, or merge it anywhere - it is rebuilt from scratch on every label change."
             echo
             if [ -n "$included" ]; then
@@ -132,6 +158,6 @@ jobs:
           } > DEVBUILD.md
 
           git add DEVBUILD.md
-          git commit -q -m "devbuild: regenerate from $BASE @ $base_sha"
+          git commit -q -m "devbuild: $dev_version - regenerate from $BASE @ $base_sha"
           git push -q --force origin HEAD:devbuild
-          echo "devbuild regenerated from $BASE @ $base_sha"
+          echo "devbuild $dev_version regenerated from $BASE @ $base_sha"


### PR DESCRIPTION
## What

The devbuild regenerate step now stamps `addons/main/script_version.hpp` on the generated branch, so dev builds carry their own in-game version instead of inheriting Main's verbatim.

## How the number is derived

- **Version**: Main's version with PATCHLVL+1 - dev builds always work toward the next release (Main at 0.7.9 -> dev cycle 0.7.10).
- **BUILD counter**: reads the previous devbuild tip's stamp; same cycle -> increment, cycle changed (a release bumped Main) -> reset to 1. First build after the 0.7.9 release is `0.7.10.1`, continuing the `0.7.9.1-4` convention from #582.
- The counter ticks on every rebuild (including PR synchronize), so every distinct binary gets a distinct number - a tester report against `0.7.10.3` identifies the exact build.

## Why it cannot touch Main

The stamp is written by the workflow onto the machine-generated, force-pushed `devbuild` branch only - the same way `DEVBUILD.md` already is. Nothing on that branch merges back, and each rebuild re-derives the stamp from Main's file plus the previous devbuild tip. Release flow on Main is unchanged.

## Side effects

- `DEVBUILD.md` and the devbuild commit message now record the stamped version.
- `push_dev.py` with no `--version`/`--bump` uses the ref's version as-is, so devbuild Workshop pushes no longer need a manual version flag.
- Fixes testers being unable to tell dev from stable in-game (both previously showed 0.7.9.0).