### PR TITLE
REFACTOR: Move Animations to a single owner

### DIFF
--- a/addons/UH60/config/cfgAnimationSources.hpp
+++ b/addons/UH60/config/cfgAnimationSources.hpp
@@ -217,19 +217,19 @@ class AnimationSources {
     animPeriod=1;
     initPhase=0;
   };
-  class cabindoor_L {
+  class cabindoor_L: LandingLight_Show {
     displayName = "Close L Cabin Door";
     source="user";
     animPeriod=1;
     initPhase=0;
   };
-  class cabindoor_R {
+  class cabindoor_R: LandingLight_Show {
     displayName = "Close R Cabin Door";
     source="user";
     animPeriod=1;
     initPhase=0;
   };
-  class Stabilator_rotate_user {
+  class Stabilator_rotate_user: LandingLight_Show {
     source="user";
     animPeriod=1;
     initPhase=0;

--- a/addons/UH60/config/cfgAnimationSources.hpp
+++ b/addons/UH60/config/cfgAnimationSources.hpp
@@ -15,9 +15,10 @@ class AnimationSources {
   ANIMSRC(rotorHide_User,user,1,0);
   ANIMSRC(tailRotorHide_User,user,1,0);
   // Rotate rotor hub to folding alignment
+  // animPeriod/initPhase: live values per uh60_config's former duplicate (Phase 1 WP1 collision ruling)
   class RotorHFold {
-      animPeriod = 1;
-      initPhase = -0.125;
+      animPeriod = 5;
+      initPhase = 0;
       source = "user";
   };
   class RotorVFold: RotorHFold {

--- a/addons/uh60_config/config/CfgAnimationSources.hpp
+++ b/addons/uh60_config/config/CfgAnimationSources.hpp
@@ -1,17 +1,28 @@
+// Phase 1 (WP1): vtx_H60_base's AnimationSources are owned by vtx_UH60
+// (UH60/config/cfgAnimationSources.hpp). This file is an honest delta: it only
+// ADDS sources or EXTENDS existing ones with properties this addon owns
+// (MASS_* weight logic, forceAnimate wiring, onPhaseChanged handlers, the
+// blade-fold set, FFV windows, wipers). Re-opened classes carry only the
+// added properties; duplicated declarations were removed 2026-09-05 after the
+// live merged values were captured in the WP0 config-dump baseline.
 class AnimationSources: AnimationSources {
+  // owned by UH60; forward-declared so parents resolve at rapify time —
+  // referenced below and by the variant blocks' ANIM_INIT re-opens
+  class LandingLight_Show;
+  class ACCLow;
+  class RotorHFold;
+  class Hoist_hide;
+  class cabindoor_L;
+  class cabindoor_R;
+  class HH60GRadar_show;
+  class HH60GFlir_show;
+
   class GunnerSeats_Hide {
     displayName = "Hide Gunner Seats";
-    source="user";
-    animPeriod=1;
-    initPhase=0;
     mass = -MASS_GUNNERSEATS;
     onPhaseChanged = "params ['_vehicle', '_phase']; {_vehicle lockTurret [_x, _phase == 1]} forEach [[1], [2]] ;";
   };
   class CabinSeats_Hide {
-    //displayName = "Hide Cabin Seats";
-    source="user";
-    animPeriod=1;
-    initPhase=0;
     mass = -MASS_CABINSEATS;
     lockCargoAnimationPhase = 1;
     //lockCargo[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
@@ -25,17 +36,11 @@ class AnimationSources: AnimationSources {
     };
   };
   class CabinSeats_1_Hide {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
     mass = -MASS_CABINSEATS3;
     //lockCargoAnimationPhase = 1;
     //lockCargo[] = { 8, 9, 10 };
   };
   class CabinSeats_2_Hide {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
     mass = -MASS_CABINSEATS4;
     //lockCargoAnimationPhase = 1;
     //lockCargo[] = { 4, 5, 6, 7 };
@@ -46,9 +51,6 @@ class AnimationSources: AnimationSources {
     };
   };
   class CabinSeats_3_Hide {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
     mass = -MASS_CABINSEATS4;
     //lockCargoAnimationPhase = 1;
     //lockCargo[] = { 0, 1, 2, 3 };
@@ -60,66 +62,26 @@ class AnimationSources: AnimationSources {
     };
   };
   class Minigun_Mount_L_hide {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
     mass = -MASS_GUNMOUNT;
     forceAnimatePhase = 1;
     forceAnimate[] = { "Minigun_L_hide", 1 };
   };
   class Minigun_Mount_R_hide {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
     mass = -MASS_GUNMOUNT;
     forceAnimatePhase = 1;
     forceAnimate[] = { "Minigun_R_hide", 1 };
   };
   class Minigun_L_hide {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
     mass = -MASS_MINIGUN;
   };
   class Minigun_R_hide {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
     mass = -MASS_MINIGUN;
   };
-  class Minigun_Sight_L_hide {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class Minigun_Sight_R_hide {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
   class RADAR_HIDE {
-    //displayName = "Hide Radar";
-    source="user";
-    animPeriod=1;
-    initPhase=1;
     mass = -MASS_RADAR;
   };
   class FLIR_HIDE {
-    //displayName = "Hide FLIR";
-    source="user";
-    animPeriod=1;
-    initPhase=1;
     mass = -MASS_FLIR;
-  };
-  class FLIR_DIRECTION {
-    source="user";
-    animPeriod=1;
-    initPhase="rad 180";
-  };
-  class FLIR_ELEVATION {
-    source="user";
-    animPeriod=1;
-    initPhase="rad 80";
   };
   class PylonForward_L {
     source="user";
@@ -132,10 +94,6 @@ class AnimationSources: AnimationSources {
     initPhase=0;
   };
   class ERFS_show {
-    //displayName = "Show ERFS";
-    source="user";
-    animPeriod=1;
-    initPhase=0;
     mass = MASS_ERFS;
     forceAnimatePhase = 1;
     forceAnimate[] = {
@@ -145,18 +103,10 @@ class AnimationSources: AnimationSources {
     };
   };
   class MAWS_Tubes_Show {
-    //displayName = "Show MAWS";
-    source="user";
-    animPeriod=1;
-    initPhase=0;
     //mass = MASS_MAWS; // only adjusts position
     onPhaseChanged = "params ['_vehicle', '_phase']; _vehicle animate ['MAWS_Stubs_hide', _phase, true];";
   };
   class LASS_show {
-    //displayName = "Show LASS";
-    source="user";
-    animPeriod=1;
-    initPhase=0;
     mass = MASS_LASS;
     forceAnimatePhase = 1;
     forceAnimate[] = {
@@ -165,10 +115,6 @@ class AnimationSources: AnimationSources {
     };
   };
   class MLASS_show {
-    //displayName = "Show LASS";
-    source="user";
-    animPeriod=1;
-    initPhase=0;
     mass = MASS_LASS;
     forceAnimatePhase = 1;
     forceAnimate[] = {
@@ -177,10 +123,6 @@ class AnimationSources: AnimationSources {
     };
   };
   class ESSS_show {
-    //displayName = "Show ESSS";
-    source="user";
-    animPeriod=1;
-    initPhase=0;
     mass = MASS_ESSS;
     forceAnimatePhase = 1;
     forceAnimate[] = {
@@ -201,9 +143,6 @@ class AnimationSources: AnimationSources {
     };
   };
   class GAU21_L_Hide {
-    source="user";
-    animPeriod=1;
-    initPhase=1;
     mass = -MASS_GAU21;
     forceAnimatePhase = 0;
     forceAnimate[] = {
@@ -212,9 +151,6 @@ class AnimationSources: AnimationSources {
     };
   };
   class GAU21_R_Hide {
-    source="user";
-    animPeriod=1;
-    initPhase=1;
     mass = -MASS_GAU21;
     forceAnimatePhase = 0;
     forceAnimate[] = {
@@ -223,30 +159,10 @@ class AnimationSources: AnimationSources {
     };
   };
   class Skis_show {
-    displayName = "Show Skis";
-    source="user";
-    animPeriod=1;
-    initPhase=0;
     mass = MASS_SKIS;
   };
   class HH60Flares_show {
-    //displayName = "Show HH-60 Flares";
-    source="user";
-    animPeriod=1;
-    initPhase=0;
     mass = MASS_HH60FLARES;
-  };
-  class HH60GRadar_show {
-    //displayName = "Show HH-60 Weather Radar";
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class HH60GFlir_show {
-    //displayName = "Show HH-60 Flir";
-    source="user";
-    animPeriod=1;
-    initPhase=0;
   };
   class MH60MMisc_show {
     //displayName = "Show MH-60M Exterior parts";
@@ -256,335 +172,21 @@ class AnimationSources: AnimationSources {
     mass = MASS_MH60M_MISC;
   };
   class Fuelprobe_show {
-    //displayName = "Show Fuel Probe";
-    source="user";
-    animPeriod=1;
-    initPhase=0;
     mass = MASS_PROBE;
   };
-  class Door_LF_Hide {
-    displayName = "Hide Left Cockpit Door";
-    source = "user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class Door_RF_Hide {
-    displayName = "Hide Right Cockpit Door";
-    source = "user";
-    animPeriod=1;
-    initPhase=0;
-  };
   class Cockpitdoors_Hide {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
     mass = -MASS_COCKPITDOORS;
-  };
-  class LandingLight_Show {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
   };
   class SearchLight_Show: LandingLight_Show {};
   class window_l: LandingLight_Show {};
   class window_r: LandingLight_Show {};
-  class Stabilator_rotate_user: LandingLight_Show {};
-  class cabindoor_L: LandingLight_Show {displayName = "Close L Cabin Door";};
-  class cabindoor_R: LandingLight_Show {displayName = "Close R Cabin Door";};
-  ANIMSRC(hoist_hide,user,1,0);
-  ANIMSRC(hoist_hook_hide,user,1,0);
-  //interriorparts
-  ANIMSRC(cockpitlight_show,user,1,0);
-  ANIMSRC(cabinlight_show,user,1,0);
-  class MAP_X {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class MAP_Y {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class MAP_Rotation {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class MAP1_Scale {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class COMM1_ROT {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class COMM2_ROT:COMM1_ROT{};
-  class COMM3_ROT:COMM1_ROT{};
-  class COMM4_ROT:COMM1_ROT{};
-  class MVOL_ROT {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class TX_ROT {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class FD_1_ROT {
-    source="user";
-    animPeriod=1;
-    initPhase=0.5;
-  };
-  class FD_2_ROT:FD_1_ROT{};
-  class FD_3_ROT:FD_1_ROT{};
-  class FD_4_ROT:FD_1_ROT{};
-  class FD_5_ROT:FD_1_ROT{};
-  class ACCLow {
-    source="user";
-    animPeriod=0.00001;
-    initPhase=0;
-  };
-  class APUFail:ACCLow{};
-  class APUOn:ACCLow{};
-  class BattGood:ACCLow{};
-  class BattLow:ACCLow{};
-  class EmerRlse:ACCLow{};
-  class OilHot:ACCLow{};
-  class TestLte:ACCLow{};
-  class CautionEng1Out:ACCLow{};
-  class CautionEng2Out:ACCLow{};
-  class CautionFire:ACCLow{};
-  class CautionMasterCaution:ACCLow{};
-  class Wipers:ACCLow{};
-  class Gauge_temp {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class Lever_RotorBrake {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class Knob_LightInstPanel {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class Knob_LightLowerConsole {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class Knob_LightUpperConsole {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class Knob_Lights_Formation {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class Switch_lights_position {
-    source="user";
-    animPeriod=1;
-    initPhase=0.5;
-  };
-  class Switch_lights_collision {
-    source="user";
-    animPeriod=1;
-    initPhase=0.5;
-  };
-  class Switch_lights_cockpit {
-    source="user";
-    animPeriod=1;
-    initPhase=0.5;
-  };
-  class MFD1_hide {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class MFD2_hide {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class MFD3_hide {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class MFD4_hide {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class ESIS_hide {
-    source="user";
-    animPeriod=1;
-    initPhase=1;
-  };
-  class PowerOnOff {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class GeneratorsOnOff {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class Switch_fuelboostpump1 {
-    source="user";
-    animPeriod=1;
-    initPhase=0.5;
-  };
-  class Switch_fuelboostpump2 {
-    source="user";
-    animPeriod=1;
-    initPhase=0.5;
-  };
-  class Switch_batt1 {
-    source="user";
-    animPeriod=1;
-    initPhase=0.5;
-  };
-  class Switch_batt2 {
-    source="user";
-    animPeriod=1;
-    initPhase=0.5;
-  };
-  class Switch_stbyinst {
-    source="user";
-    animPeriod=1;
-    initPhase=0.5;
-  };
-  class Switch_airsce {
-    source="user";
-    animPeriod=1;
-    initPhase=0.5;
-  };
-  class Lever_fuelsys1 {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class Lever_fuelsys2 {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class Lever_engpower1 {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class Lever_engpower2 {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class Switch_ignition {
-    source="user";
-    animPeriod=1;
-    initPhase=0;
-  };
-  class Switch_gen1 {
-    source="user";
-    animPeriod=1;
-    initPhase=0.5;
-  };
-  class Handle_wheelbrake {
-    source="user";
-    animPeriod=1;
-    initPhase=1;
-  };
-  class Switch_gen2 {
-    source="user";
-    animPeriod=1;
-    initPhase=0.5;
-  };
-  class Switch_apugen {
-    source="user";
-    animPeriod=1;
-    initPhase=0.5;
-  };
-  class Switch_apucont {
-    source="user";
-    animPeriod=1;
-    initPhase=0.5;
-  };
-  class Switch_fuelpump {
-    source="user";
-    animPeriod=1;
-    initPhase=0.5;
-  };
-  class wheel_dumper_l {
-    source="damper";
-    wheel="Wheel_1";
-  };
-  class wheel_dumper_r {
-    source="damper";
-    wheel="Wheel_2";
-  };
-  class wheel_dumper_rear {
-    source="damper";
-    wheel="Wheel_3";
-  };
-  class Wheel_l_source {
-    source="wheel";
-    wheel="Wheel_1";
-  };
-  class Wheel_r_source {
-    source="wheel";
-    wheel="Wheel_2";
-  };
-  class Wheel_rear_source {
-    source="wheel";
-    wheel="Wheel_3";
-  };
-  class Gatling_1 {
-    source="revolving";
-    weapon="vtx_wpn_m134";
-  };
-  class Gatling_2 {
-    source="revolving";
-    weapon="vtx_wpn_m134_2nd";
-  };
-  class Muzzle_Flash_M134_L {
-    source="ammoRandom";
-    weapon="vtx_wpn_m134";
-  };
-  class Muzzle_Flash_M134_R {
-    source="ammoRandom";
-    weapon="vtx_wpn_m134_2nd";
-  };
-  class Switch_minigun_safe_cover_l {
-    source="user";
-    animPeriod=0.2;
-    initPhase=0;
-  };
-  class Switch_minigun_safe_cover_r: Switch_minigun_safe_cover_l {};
-  class Switch_minigun_safe_l: Switch_minigun_safe_cover_l {};
-  class Switch_minigun_safe_r: Switch_minigun_safe_cover_l {};
+  class Wipers: ACCLow {};
   class window_l_ffv {
     source = "door";
     animPeriod = 1;
     initPhase = 0;
   };
   class window_r_ffv: window_l_ffv {};
-  class RotorHFold {
-    source="user";
-    animPeriod=5;
-    initPhase=0;
-  };
-  class RotorVFold: RotorHFold {};
   class Fold_Stabilator_rotate: RotorHFold {};
   class Fold_Stabilator_l: RotorHFold {};
   class Fold_Stabilator_r: RotorHFold {};


### PR DESCRIPTION
**When merged this pull request will:**
- RotorHFold now carries animPeriod=5; initPhase=0 in UH60 — these were already the live values (uh60_config's copy won); UH60's old 1/-0.125 never took effect.
- cabindoor_L/R and Stabilator_rotate_user gain explicit : LandingLight_Show — the engine had already recorded that parent from uh60_config's re-declaration
- The forward-declaration block at the top of uh60_config's file is required: variant-level ANIM_INIT re-opens must resolve their base class at rapify time.
