### PR TITLE
Feature Request/BugFix: Adds TDC Waypoint Set Keybind & Slew for FLIR Targeting / Fixes a MFD Create Waypoint issue of it not creating one on press.

### DIFF
--- a/addons/uh60_fd/functions/defines.hpp
+++ b/addons/uh60_fd/functions/defines.hpp
@@ -23,12 +23,13 @@
 #define IAS_ANIM_STR "FD_4_ROT"
 #define HDG_ANIM_STR "FD_5_ROT"
 
-#define GET_RALT ((round (ANIM(RALT_ANIM_STR)*10))*10)
-#define GET_ALT    ((round (ANIM(ALT_ANIM_STR)*10))*100)
-#define GET_ALTP ((round (ANIM(ALTP_ANIM_STR)*10))*100)
-#define GET_IAS    ((round (ANIM(IAS_ANIM_STR)*10))*10)
+#define SAFE_NUM(X) ([0, X] select (finite (X)))
+#define GET_RALT SAFE_NUM((round (ANIM(RALT_ANIM_STR)*10))*10)
+#define GET_ALT    SAFE_NUM((round (ANIM(ALT_ANIM_STR)*10))*100)
+#define GET_ALTP SAFE_NUM((round (ANIM(ALTP_ANIM_STR)*10))*100)
+#define GET_IAS    SAFE_NUM((round (ANIM(IAS_ANIM_STR)*10))*10)
 //#define GET_HDG    ((round (ANIM(HDG_ANIM_STR)))*36)
-#define GET_HDG    (round(ANIM(HDG_ANIM_STR)*36))
+#define GET_HDG    SAFE_NUM(round(ANIM(HDG_ANIM_STR)*36))
 #define GET_VS     (GET("vs_val",0))
 
 #define SET_RALT(FT) (SET_ANIM(RALT_ANIM_STR,(round(FT/10)/10)))

--- a/addons/uh60_flir/Armakeybinds.hpp
+++ b/addons/uh60_flir/Armakeybinds.hpp
@@ -56,6 +56,22 @@ class CfgUserActions
 		onAnalog = "";	// _this is the scalar analog value.
 		analogChangeThreshold = 0.1; // Minimum change required to trigger the onAnalog EH (default: 0.01).
 	};
+	class Vtx_Flir_TdcWaypointSet {
+		displayName = "TDC Waypoint Set";
+		tooltip = "Mark a waypoint at wherever FLIR is currently designating.";
+		onActivate = "call vtx_uh60_flir_fnc_keyTdcWaypointSet;";		// _this is always true.
+		onDeactivate = "";		// _this is always false.
+		onAnalog = "";	// _this is the scalar analog value.
+		analogChangeThreshold = 0.1; // Minimum change required to trigger the onAnalog EH (default: 0.01).
+	};
+	class Vtx_Flir_TdcSlewWaypoint {
+		displayName = "TDC Slew Waypoint";
+		tooltip = "Slew FLIR to the current group waypoint.";
+		onActivate = "call vtx_uh60_flir_fnc_keyTdcSlewWaypoint;";		// _this is always true.
+		onDeactivate = "";		// _this is always false.
+		onAnalog = "";	// _this is the scalar analog value.
+		analogChangeThreshold = 0.1; // Minimum change required to trigger the onAnalog EH (default: 0.01).
+	};
 };
 class CfgDefaultKeysPresets {};
 class UserActionGroups
@@ -70,7 +86,9 @@ class UserActionGroups
 		"Vtx_Flir_SlewUp",
 		"Vtx_Flir_SlewDown",
 		"Vtx_Flir_SlewLeft",
-		"Vtx_Flir_SlewRight"
+		"Vtx_Flir_SlewRight",
+		"Vtx_Flir_TdcWaypointSet",
+		"Vtx_Flir_TdcSlewWaypoint"
 		}; // List of all actions inside this category.
 	};
 };

--- a/addons/uh60_flir/XEH_PREP.hpp
+++ b/addons/uh60_flir/XEH_PREP.hpp
@@ -10,6 +10,8 @@ PREP(handleKeyInputs);
 PREP(handleSlew);
 PREP(initVars);
 PREP(keyFLIRSlewToHMD);
+PREP(keyTdcWaypointSet);
+PREP(keyTdcSlewWaypoint);
 PREP(keyVisionMode);
 PREP(keyZoom);
 PREP(mfdNav);

--- a/addons/uh60_flir/XEH_postInit.sqf
+++ b/addons/uh60_flir/XEH_postInit.sqf
@@ -1,5 +1,7 @@
 #include "script_component.hpp"
 
+vtx_uh60_flir_tdcWaypointNum = 99;
+
 if (hasInterface) then {
     #include "initKeybinds.sqf"
 };

--- a/addons/uh60_flir/functions/fnc_interaction.sqf
+++ b/addons/uh60_flir/functions/fnc_interaction.sqf
@@ -3,25 +3,10 @@ params ["_vehicle", "_button", "_var"];
 	// systemchat str _this;
 switch (_button) do {
 	case "WAYPT_SLEW": {
-		private _currentWaypointIndex = currentWaypoint group player;
-		private _waypoints = waypoints group player;
-
-		if (_currentWaypointIndex < count _waypoints) exitWith { // valid base game waypoint
-			private _target = AGLToASL waypointPosition [group player, _currentWaypointIndex];
-			_vehicle setPilotCameraTarget _target;
-			[[], _target] call vtx_uh60_flir_fnc_syncPilotCamera;
-		};
+		call vtx_uh60_flir_fnc_keyTdcSlewWaypoint;
 	};
 	case "WAYPT_CREATE": {
-		(getPilotCameraTarget _vehicle) params ["_stabilized", "_position"];
-		if (!_stabilized) exitWith {};
-		private _targets = _vehicle getVariable ["vtx_uh60_flir_targets", 0];
-        [
-            format ["TGT %1 %2", _targets + 1, name player],
-            _position,
-            ""
-        ] call vtx_uh60_fms_fnc_addWaypoint;
-		_vehicle setVariable ["vtx_uh60_flir_targets", _targets + 1];
+		call vtx_uh60_flir_fnc_keyTdcWaypointSet;
 	};
 	case "LST_CHAN": {
 		//private _laserCodeIndex = _vehicle ammoOnPylon 44;

--- a/addons/uh60_flir/functions/fnc_keyTdcSlewWaypoint.sqf
+++ b/addons/uh60_flir/functions/fnc_keyTdcSlewWaypoint.sqf
@@ -1,0 +1,28 @@
+#include "script_component.hpp"
+/*
+ * Author: Perk
+ * Slew FLIR to the current group waypoint same as the FLIR page's
+ * "Slew To Waypoint" button.
+ *
+ * Arguments:
+ * NONE
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * call vtx_uh60_flir_fnc_keyTdcSlewWaypoint
+ */
+
+IS_EITHER_PILOT;
+
+if (!vtx_uh60_flir_controllable) exitWith {};
+
+private _currentWaypointIndex = currentWaypoint group player;
+private _waypoints = waypoints group player;
+
+if (_currentWaypointIndex >= count _waypoints) exitWith {}; // no valid waypoint
+
+private _target = AGLToASL waypointPosition [group player, _currentWaypointIndex];
+hct_vehicle setPilotCameraTarget _target;
+[[], _target] call vtx_uh60_flir_fnc_syncPilotCamera;

--- a/addons/uh60_flir/functions/fnc_keyTdcWaypointSet.sqf
+++ b/addons/uh60_flir/functions/fnc_keyTdcWaypointSet.sqf
@@ -1,0 +1,35 @@
+#include "script_component.hpp"
+/*
+ * Author: Perk
+ * Mark a waypoint at wherever FLIR is currently designating (TDC). Numbers
+ * count down from 99 so they don't collide with mission planned waypoints,
+ *
+ * Arguments:
+ * NONE
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * call vtx_uh60_flir_fnc_keyTdcWaypointSet
+ */
+
+IS_EITHER_PILOT;
+
+if (!vtx_uh60_flir_controllable) exitWith {};
+
+getPilotCameraTarget hct_vehicle params ["_isTracking", "_tgtPosASL", ""];
+
+private _trackedObj = vtx_uh60_flir_pilotCameraTarget param [2, objNull];
+if (!isNull _trackedObj) then {
+  _isTracking = true;
+  _tgtPosASL = getPosASLVisual _trackedObj;
+};
+
+if (!_isTracking) exitWith {}; // nothing designated to mark
+
+[str vtx_uh60_flir_tdcWaypointNum, ASLToAGL _tgtPosASL, ""] call vtx_uh60_fms_fnc_addWaypoint;
+
+if (vtx_uh60_flir_tdcWaypointNum > 2) then {
+  vtx_uh60_flir_tdcWaypointNum = vtx_uh60_flir_tdcWaypointNum - 1;
+};

--- a/addons/uh60_flir/functions/fnc_setFOV.sqf
+++ b/addons/uh60_flir/functions/fnc_setFOV.sqf
@@ -20,7 +20,9 @@ vtx_uh60_flir_camera camSetFov _fov;
 if (_sync) then {
   // ["vtx_uh60_flir_syncFOV", [_fov], [vtx_uh60_flir_otherPilot]] call CBA_fnc_targetEvent;
   private _targets = (crew vehicle player) - [player];
-  [_fov, false] remoteExecCall ["vtx_uh60_flir_fnc_setFOV", _targets, false];
+  if (_targets isNotEqualTo []) then {
+    [_fov, false] remoteExecCall ["vtx_uh60_flir_fnc_setFOV", _targets, false];
+  };
 };
 
 

--- a/addons/uh60_flir/initKeybinds.sqf
+++ b/addons/uh60_flir/initKeybinds.sqf
@@ -85,6 +85,24 @@ addUserActionEventHandler ["hideMap", "Activate", {
     [241, [false, true, false]],false
 ] call CBA_fnc_addKeybind;
 
+[
+    "UH-60M Blackhawk","vtx_uh60_flir_tdcWaypointSet","TDC Waypoint Set",
+    {
+      call vtx_uh60_flir_fnc_keyTdcWaypointSet;
+      false
+    },{},
+    [-1, [false, false, false]],false
+] call CBA_fnc_addKeybind;
+
+[
+    "UH-60M Blackhawk","vtx_uh60_flir_tdcSlewWaypoint","TDC Slew Waypoint",
+    {
+      call vtx_uh60_flir_fnc_keyTdcSlewWaypoint;
+      false
+    },{},
+    [-1, [false, false, false]],false
+] call CBA_fnc_addKeybind;
+
 /* Use base game keybind
 [
     "UH-60M Blackhawk","vtx_uh60_flir_c_stabilize","FLIR Stabilize", // Ctrl + T

--- a/addons/uh60_flir/initKeybinds.sqf
+++ b/addons/uh60_flir/initKeybinds.sqf
@@ -85,24 +85,6 @@ addUserActionEventHandler ["hideMap", "Activate", {
     [241, [false, true, false]],false
 ] call CBA_fnc_addKeybind;
 
-[
-    "UH-60M Blackhawk","vtx_uh60_flir_tdcWaypointSet","TDC Waypoint Set",
-    {
-      call vtx_uh60_flir_fnc_keyTdcWaypointSet;
-      false
-    },{},
-    [-1, [false, false, false]],false
-] call CBA_fnc_addKeybind;
-
-[
-    "UH-60M Blackhawk","vtx_uh60_flir_tdcSlewWaypoint","TDC Slew Waypoint",
-    {
-      call vtx_uh60_flir_fnc_keyTdcSlewWaypoint;
-      false
-    },{},
-    [-1, [false, false, false]],false
-] call CBA_fnc_addKeybind;
-
 /* Use base game keybind
 [
     "UH-60M Blackhawk","vtx_uh60_flir_c_stabilize","FLIR Stabilize", // Ctrl + T

--- a/addons/uh60_fms/functions/fnc_interaction_waypoint.sqf
+++ b/addons/uh60_fms/functions/fnc_interaction_waypoint.sqf
@@ -11,8 +11,16 @@ params ["_vehicle", "_action", "_value", ["_pageData", nil]];
 switch (_action) do {
     case "cycle": {
         private _group = group player;
-        private _waypointIndex = currentWaypoint _group;
-        [player, "", (_waypointIndex + _value)] call vtx_uh60_fms_fnc_selectWaypoint;
+        private _count = count (waypoints _group);
+
+        private _current = missionNamespace getVariable ["vtx_uh60_fms_wpSelection", currentWaypoint _group];
+        private _new = _current + _value;
+        if (_new < -1) then { _new = _count - 1 };
+        if (_new >= _count) then { _new = -1 };
+        vtx_uh60_fms_wpSelection = _new;
+        if (_new > -1) then {
+            [player, "", _new] call vtx_uh60_fms_fnc_selectWaypoint;
+        };
     };
     case "import": {
         private _waypoints = waypoints group player;
@@ -75,35 +83,35 @@ switch (_action) do {
         };
         _vehicle setUserMFDvalue _pageData;
     };
-    case "send": { 
+    case "send": {
         private _wayPoint = [group player, currentWaypoint group player];
         private _position = waypointPosition _wayPoint;
 
-        private _sender = profileName; 
-        private _recipient = "ALL"; 
-        private _id = "XMIT WAYPT"; 
+        private _sender = profileName;
+        private _recipient = "ALL";
+        private _id = "XMIT WAYPT";
         private _messageContent = [
             mapGridPosition _position,
             str (_position # 2),
             waypointDescription _wayPoint,
             "AUTO SENT FROM FMS",
-            "", 
-            "", 
-            "", 
-            "", 
-            "", 
+            "",
+            "",
+            "",
+            "",
+            "",
             ""
-        ]; 
-        private _message = [_id, _sender, _recipient, 2, _messageContent, [_position], [[_timestamp, _sender, "SENT"]]]; 
+        ];
+        private _message = [_id, _sender, _recipient, 2, _messageContent, [_position], [[_timestamp, _sender, "SENT"]]];
         _message call vtx_uh60_jvmf_fnc_attemptSendMessage;
     };
-    case "slew_flir_waypt": { 
+    case "slew_flir_waypt": {
         private _wayPoint = [group player, currentWaypoint group player];
         private _position = waypointPosition _wayPoint;
         _vehicle setPilotCameraTarget (AGLtoASL (_position));
         [getPilotCameraDirection _vehicle, AGLtoASL _position] call vtx_uh60_flir_fnc_syncPilotCamera;
     };
-    case "slew_flir": { 
+    case "slew_flir": {
         if (isNil "fms_locations_selected") exitWith {};
         private _location = fms_locations_selected;
         _vehicle setPilotCameraTarget (AGLtoASL (locationPosition _location));

--- a/addons/uh60_fms/functions/fnc_perFrame.sqf
+++ b/addons/uh60_fms/functions/fnc_perFrame.sqf
@@ -65,7 +65,11 @@ private _strings = switch ((getUserMFDValue _vehicle) # _fms) do {
 if ((count customWaypointPosition) > 0) then {
     _vehicle setUserMFDvalue [1, _vehicle distance2D customWaypointPosition];
 } else {
-    private _wayPoint = [group player, currentWaypoint group player];
-    private _position = waypointPosition _wayPoint;
+    private _selIndex = missionNamespace getVariable ["vtx_uh60_fms_wpSelection", currentWaypoint group player];
+    private _position = if (_selIndex > -1 && {_selIndex < count (waypoints group player)}) then {
+        waypointPosition [group player, _selIndex]
+    } else {
+        [0,0,0]
+    };
     _vehicle setUserMFDvalue [1, _vehicle distance2D _position];
 };

--- a/addons/uh60_fms/functions/fnc_perSecond.sqf
+++ b/addons/uh60_fms/functions/fnc_perSecond.sqf
@@ -33,16 +33,17 @@ private _strings = switch ((getUserMFDValue _vehicle) # _fms) do {
         ]
     };
     case FMS_PAGE_NAV_WAYPOINT: {
-        private _waypointIndex = currentWaypoint group player;
-        private _wayPoint = [group player, _waypointIndex];
-        private _position = waypointPosition _wayPoint;
-        private _gridArea = [worldName] call ace_common_fnc_getMGRSdata;
-        private _grid = [_position] call ace_common_fnc_getMapGridFromPos;
-        private _str = format ["%1    %2    %3    %4", _gridArea select 0, _gridArea select 1, _grid select 0, _grid select 1];
-        if (_waypointIndex < count (waypoints group player)) then {
-          [_str, format["%1/%2", _waypointIndex + 1, count (waypoints group player)], "", "",""]
+        private _waypoints = waypoints group player;
+        private _waypointIndex = missionNamespace getVariable ["vtx_uh60_fms_wpSelection", currentWaypoint group player];
+        if (_waypointIndex == -1 || {_waypointIndex >= count _waypoints}) then {
+          ["", format["%1/%2", 0, count _waypoints], "", "",""]
         } else {
-          [_str, format["%1/%2", 0, 0], "", "",""]
+          private _wayPoint = [group player, _waypointIndex];
+          private _position = waypointPosition _wayPoint;
+          private _gridArea = [worldName] call ace_common_fnc_getMGRSdata;
+          private _grid = [_position] call ace_common_fnc_getMapGridFromPos;
+          private _str = format ["%1    %2    %3    %4", _gridArea select 0, _gridArea select 1, _grid select 0, _grid select 1];
+          [_str, format["%1/%2", _waypointIndex + 1, count _waypoints], "", "",""]
         }
     };
     case FMS_PAGE_NAV_IMPORT: {

--- a/addons/uh60_fms/functions/fnc_updateWaypointInfo.sqf
+++ b/addons/uh60_fms/functions/fnc_updateWaypointInfo.sqf
@@ -10,13 +10,15 @@
 if (!isNil "test_fnc_waypts") exitWith {_this call test_fnc_waypts};
 params ["_vehicle"];
 
-private _wayPoint = [group player, currentWaypoint group player];
-private _position = waypointPosition _wayPoint;
+private _selIndex = missionNamespace getVariable ["vtx_uh60_fms_wpSelection", currentWaypoint group player];
+private _selValid = _selIndex > -1 && {_selIndex < count (waypoints group player)};
+private _wayPoint = [group player, [_selIndex, 0] select (!_selValid)];
+private _position = if (_selValid) then {waypointPosition _wayPoint} else {[0,0,0]};
 if ((count customWaypointPosition) > 0) then {
     _position = customWaypointPosition;
     [_vehicle, 7, "MAP MARK"] call vtx_uh60_mfd_fnc_setUserText;
 } else {
-    [_vehicle, 7, waypointDescription _wayPoint] call vtx_uh60_mfd_fnc_setUserText;
+    [_vehicle, 7, [waypointDescription _wayPoint, ""] select (!_selValid)] call vtx_uh60_mfd_fnc_setUserText;
 };
 
 //private _centered = _vehicle ammoOnPylon 4 == 0;
@@ -58,8 +60,13 @@ private _clearPos = {
 
 if (vtx_uh60_fms_renderWaypointsOnTAC) then {
     {
-        _waypointPosition = waypointPosition [group player, (currentWaypoint group player) + _forEachIndex - 1];
-        if (_forEachIndex == (currentWaypoint group player) && (count customWaypointPosition) > 0) then {
+        private _wpSlotIndex = _selIndex + _forEachIndex - 1;
+        _waypointPosition = if (_wpSlotIndex >= 0 && {_wpSlotIndex < count (waypoints group player)}) then {
+            waypointPosition [group player, _wpSlotIndex]
+        } else {
+            [0,0,0]
+        };
+        if (_wpSlotIndex == _selIndex && (count customWaypointPosition) > 0) then {
             _waypointPosition = customWaypointPosition;
         };
         if (!(_waypointPosition isEqualTo [0,0,0])) then {


### PR DESCRIPTION
- Adds a TDC Waypoint Set keybind that drops a waypoint wherever the FLIR is currently designating, starts at waypoint 99 and goes downward so it never collides with mission planned waypoints. Also adds a TDC Slew Waypoint keybind for the existing "slew to waypoint" behavior. Both reuse the FLIR page's existing buttons under the hood instead of duplicating, which also fixed the Create Waypoint button.

- On the FMS NAV page, waypoint selection could only ever point at a real waypoint, so there was no way to back out of a selection or clear it. Cycling down from waypoint 1 now lands on 0 (nothing selected, blank readout), and cycling further wraps to the last waypoint in the list for example waypoint 99.

#371 