### PR TITLE
Bugfix: Parking Brake in SFM+ should actually work now.

### DIFF
--- a/addons/uh60_engine/functions/fnc_wheelBrakes.sqf
+++ b/addons/uh60_engine/functions/fnc_wheelBrakes.sqf
@@ -17,6 +17,10 @@ if (count _this > 2) then {
     _isEnabled = (_this # 1);
 };
 
+if (!difficultyEnabledRTD) then {
+    [_vehicle, _isEnabled] remoteExec ["setParkingBrake", _vehicle];
+};
+
 if (_isEnabled) then {
     [(_this # 0),"PARKING BRAKE",{},false,false] call vtx_uh60_cas_fnc_registerCautionAdvisory;
 } else {


### PR DESCRIPTION
- fnc_wheelBrakes only called setBrakesRTD which is for AFM, so when under SFM the lever animates but no brake torque was ever applied. This quick fix should resolve this problem.

- Issue: #619 